### PR TITLE
Update anilibria controller to new api

### DIFF
--- a/AppInit.cs
+++ b/AppInit.cs
@@ -107,7 +107,7 @@ namespace JacRed
 
         public TrackerSettings Selezen = new TrackerSettings("https://open.selezen.org");
 
-        public TrackerSettings Anilibria = new TrackerSettings("https://api.anilibria.tv");
+        public TrackerSettings Anilibria = new TrackerSettings("https://anilibria.top");
 
         public TrackerSettings Animelayer = new TrackerSettings("http://animelayer.ru");
 

--- a/Controllers/CRON/AniLibriaController.cs
+++ b/Controllers/CRON/AniLibriaController.cs
@@ -1,93 +1,117 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using JacRed.Engine.CORE;
 using Microsoft.AspNetCore.Mvc;
-using JacRed.Models.tParse.AniLibria;
 using JacRed.Engine;
 using JacRed.Models.Details;
+using JacRed.Models.AniLibV1;
 
 namespace JacRed.Controllers.CRON
 {
-    [Route("/cron/anilibria/[action]")]
-    public class AniLibriaController : BaseController
-    {
-        static bool workParse = false;
+	[Route("/cron/anilibria/[action]")]
+	public class AniLibriaController : BaseController
+	{
+		static bool workParse = false;
 
-        async public Task<string> Parse(int limit)
-        {
-            if (workParse)
-                return "work";
+		async public Task<string> Parse(int limit)
+		{
+			if (workParse)
+				return "work";
 
-            workParse = true;
+			workParse = true;
 
-            if (limit == 0)
-            {
-                limit = 40;
-            }
+			if (limit == 0)
+			{
+				limit = 40;
+			}
 
-            try
-            {
-                for (int after = 0; after <= limit; after = after + 40)
-                {
+			try
+			{
+				int page = 1;
+				int perPage = 40;
+				int fetched = 0;
 
-                    var roots = await HttpClient.Get<List<RootObject>>($"{AppInit.conf.Anilibria.rqHost()}/v2/getUpdates?limit=40&after={after}&include=raw_torrent", IgnoreDeserializeObject: true, useproxy: AppInit.conf.Anilibria.useproxy);
-                    if (roots == null || roots.Count == 0)
-                        continue;
+				while (fetched < limit)
+				{
+					string url = $"{AppInit.conf.Anilibria.rqHost()}/api/v1/anime/torrents?page={page}&limit={perPage}&include=release";
+					var resp = await HttpClient.Get<TorrentsResponse>(url, IgnoreDeserializeObject: true, useproxy: AppInit.conf.Anilibria.useproxy);
+					if (resp == null || resp.data == null || resp.data.Count == 0)
+						break;
 
-                    foreach (var root in roots)
-                    {
-                        var torrents = new List<TorrentBaseDetails>();
-                        DateTime createTime = new DateTime(1970, 1, 1, 0, 0, 0, 0).AddSeconds(root.last_change > root.updated ? root.last_change : root.updated);
+					var torrents = new List<TorrentBaseDetails>();
+					foreach (var item in resp.data)
+					{
+						if (item.release == null || string.IsNullOrWhiteSpace(item.magnet))
+							continue;
 
-                        foreach (var torrent in root.torrents.list)
-                        {
-                            if (string.IsNullOrWhiteSpace(root.code) || 480 >= torrent.quality.resolution && string.IsNullOrWhiteSpace(torrent.quality.encoder) && string.IsNullOrWhiteSpace(torrent.url))
-                                continue;
+						string nameRu = item.release.name?.main;
+						string nameEn = item.release.name?.english;
+						int year = item.release.year;
+						string quality = item.quality?.description;
+						string codec = item.codec?.label;
 
-                            // Данные раздачи
-                            string url = $"anilibria.tv:{root.code}:{torrent.quality.resolution}:{torrent.quality.encoder}";
-                            string title = $"{root.names.ru} / {root.names.en} {root.season.year} (s{root.season.code}, e{torrent.series.@string}) [{torrent.quality.@string}]";
+						if (string.IsNullOrWhiteSpace(nameRu) || string.IsNullOrWhiteSpace(nameEn))
+							continue;
 
-                            #region Получаем/Обновляем магнет
-                            if (string.IsNullOrWhiteSpace(torrent.raw_base64_file))
-                                continue;
+						// Build unique url id similar to previous scheme, but v1 based
+						string urlId = $"aniliberty:{item.release.id}:{(quality ?? "")}:{(codec ?? "")}";
 
-                            byte[] _t = Convert.FromBase64String(torrent.raw_base64_file);
-                            string magnet = BencodeTo.Magnet(_t);
-                            string sizeName = BencodeTo.SizeName(_t);
+						DateTime createTime = default;
+						if (DateTime.TryParse(item.updated_at, out DateTime upd))
+							createTime = upd;
+						else if (DateTime.TryParse(item.created_at, out DateTime crt))
+							createTime = crt;
+						if (createTime == default)
+							createTime = DateTime.UtcNow;
 
-                            if (string.IsNullOrWhiteSpace(magnet) || string.IsNullOrWhiteSpace(sizeName))
-                                continue;
-                            #endregion
+						string title = $"{nameRu} / {nameEn} {year} [{quality}{(string.IsNullOrWhiteSpace(codec) ? "" : ", " + codec)}]";
 
-                            torrents.Add(new TorrentBaseDetails()
-                            {
-                                trackerName = "anilibria",
-                                types = new string[] { "anime" },
-                                url = url,
-                                title = title,
-                                sid = torrent.seeders,
-                                pir = torrent.leechers,
-                                createTime = createTime,
-                                magnet = magnet,
-                                sizeName = sizeName,
-                                name = tParse.ReplaceBadNames(root.names.ru),
-                                originalname = tParse.ReplaceBadNames(root.names.en),
-                                relased = root.season.year
-                            });
-                        }
+						string sizeName = null;
+						if (item.size > 0)
+						{
+							long bytes = item.size;
+							string[] suffix = { "B", "KB", "MB", "GB", "TB" };
+							int i = 0;
+							double dbl = bytes;
+							while (i < suffix.Length && bytes >= 1024)
+							{
+								dbl = bytes / 1024.0;
+								bytes /= 1024;
+								i++;
+							}
+							sizeName = string.Format("{0:N2} {1}", dbl, suffix[i]).Replace(",", ".");
+						}
 
-                        FileDB.AddOrUpdate(torrents);
-                    }
+						torrents.Add(new TorrentBaseDetails()
+						{
+							trackerName = "anilibria",
+							types = new string[] { "anime" },
+							url = urlId,
+							title = title,
+							sid = item.seeders,
+							pir = item.leechers,
+							createTime = createTime,
+							magnet = item.magnet,
+							sizeName = sizeName,
+							name = tParse.ReplaceBadNames(nameRu),
+							originalname = tParse.ReplaceBadNames(nameEn),
+							relased = year
+						});
+					}
 
-                    roots = null;
-                }
-            }
-            catch { }
+					FileDB.AddOrUpdate(torrents);
 
-            workParse = false;
-            return "ok";
-        }
-    }
+					fetched += resp.data.Count;
+					page++;
+					await Task.Delay(200);
+				}
+			}
+			catch { }
+
+			workParse = false;
+			return "ok";
+		}
+	}
 }

--- a/Controllers/CRON/AniLibriaController.cs
+++ b/Controllers/CRON/AniLibriaController.cs
@@ -15,17 +15,14 @@ namespace JacRed.Controllers.CRON
 	{
 		static bool workParse = false;
 
-		async public Task<string> Parse(int limit)
+		async public Task<string> Parse()
 		{
 			if (workParse)
 				return "work";
 
 			workParse = true;
-
-			if (limit == 0)
-			{
-				limit = 40;
-			}
+			
+			int limit = 70;
 
 			try
 			{
@@ -35,9 +32,9 @@ namespace JacRed.Controllers.CRON
 
 				while (fetched < limit)
 				{
-					string url = $"{AppInit.conf.Anilibria.rqHost()}/api/v1/anime/torrents?page={page}&limit={perPage}&include=release";
+					string url = $"{AppInit.conf.Anilibria.rqHost()}/api/v1/anime/torrents?page={page}&limit={perPage}";
 					var resp = await HttpClient.Get<TorrentsResponse>(url, IgnoreDeserializeObject: true, useproxy: AppInit.conf.Anilibria.useproxy);
-					if (resp == null || resp.data == null || resp.data.Count == 0)
+					if (resp == null || resp.data == null )
 						break;
 
 					var torrents = new List<TorrentBaseDetails>();

--- a/Models/AniLibV1/TorrentsResponse.cs
+++ b/Models/AniLibV1/TorrentsResponse.cs
@@ -1,0 +1,55 @@
+namespace JacRed.Models.AniLibV1
+{
+	public class TorrentsResponse
+	{
+		public System.Collections.Generic.List<TorrentItem> data { get; set; }
+	}
+
+	public class TorrentItem
+	{
+		public int id { get; set; }
+		public string hash { get; set; }
+		public long size { get; set; }
+		public string label { get; set; }
+		public int seeders { get; set; }
+		public int leechers { get; set; }
+		public string magnet { get; set; }
+		public TorrentQuality quality { get; set; }
+		public TorrentCodec codec { get; set; }
+		public string created_at { get; set; }
+		public string updated_at { get; set; }
+		public Release release { get; set; }
+	}
+
+	public class TorrentQuality
+	{
+		public string value { get; set; }
+		public string description { get; set; }
+	}
+
+	public class TorrentCodec
+	{
+		public string value { get; set; }
+		public string label { get; set; }
+	}
+
+	public class Release
+	{
+		public int id { get; set; }
+		public int year { get; set; }
+		public ReleaseName name { get; set; }
+		public ReleaseSeason season { get; set; }
+	}
+
+	public class ReleaseName
+	{
+		public string main { get; set; }
+		public string english { get; set; }
+	}
+
+	public class ReleaseSeason
+	{
+		public string value { get; set; }
+		public string description { get; set; }
+	}
+}

--- a/aniliberty_v1.json
+++ b/aniliberty_v1.json
@@ -1,0 +1,6443 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "AniLiberty",
+        "description": "AniLiberty API V1 description",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "/api/v1",
+            "description": "This server"
+        },
+        {
+            "url": "https://aniliberty.top/api/v1",
+            "description": "Main server #1"
+        }
+    ],
+    "paths": {
+        "/accounts/otp/get": {
+            "post": {
+                "tags": [
+                    "Аккаунты.ОдноразовыеПароли"
+                ],
+                "summary": "Запрашивает OTP",
+                "description": "Запрашиваем новый одноразовый пароль",
+                "operationId": "53594955e6c7f55f3787b13c20118a94",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "device_id"
+                                ],
+                                "properties": {
+                                    "device_id": {
+                                        "type": "string",
+                                        "example": "n702175b-fa52-5251-a39z-d1f4af0w1cak"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Данные OTP",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.otp.get"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Не удалось создать OTP"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                }
+            }
+        },
+        "/accounts/otp/accept": {
+            "post": {
+                "tags": [
+                    "Аккаунты.ОдноразовыеПароли"
+                ],
+                "summary": "Присоединяем пользователя к выданному OTP",
+                "description": "Присоединяем пользователя к выданному одноразовому паролю",
+                "operationId": "7fad0328b8acfe70c095adefd72c4612",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "code"
+                                ],
+                                "properties": {
+                                    "code": {
+                                        "type": "integer",
+                                        "example": 54233
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Успешная привязка пользователя к OTP"
+                    },
+                    "401": {
+                        "description": "Пользователь не авторизован"
+                    },
+                    "404": {
+                        "description": "OTP не найден"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/otp/login": {
+            "post": {
+                "tags": [
+                    "Аккаунты.ОдноразовыеПароли"
+                ],
+                "summary": "Авторизуемся по OTP",
+                "description": "Авторизуемся по выданному одноразовому паролю",
+                "operationId": "790d35f354c43efd3523b84a80ead587",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "code",
+                                    "device_id"
+                                ],
+                                "properties": {
+                                    "code": {
+                                        "type": "integer",
+                                        "example": 54233
+                                    },
+                                    "device_id": {
+                                        "type": "string",
+                                        "example": "n702175b-fa52-5251-a39z-d1f4af0w1cak"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Токен авторизации",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.otp.login"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "OTP не привязан к пользователю"
+                    },
+                    "404": {
+                        "description": "OTP не найден"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                }
+            }
+        },
+        "/accounts/users/auth/login": {
+            "post": {
+                "tags": [
+                    "Аккаунты.Пользователи.Авторизация"
+                ],
+                "summary": "Авторизация пользователя",
+                "description": "Авторизация пользователя по логину и паролю. Создание сессии пользователя, выдача токена авторизации для использования в cookies или в Bearer Token",
+                "operationId": "14fa6a915a5b4509014a513e36168abd",
+                "requestBody": {
+                    "description": "Авторизационные данные",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "login",
+                                    "password"
+                                ],
+                                "properties": {
+                                    "login": {
+                                        "type": "string",
+                                        "example": "animeshnik_488"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "example": "password"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Токен авторизации",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.auth.login"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Не указан логин и/или пароль"
+                    },
+                    "401": {
+                        "description": "Не удалось авторизоваться. Неправильные логин/пароль"
+                    }
+                }
+            }
+        },
+        "/accounts/users/auth/social/{provider}/login": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Авторизация.СоциальныеСети"
+                ],
+                "summary": "Авторизация пользователя через социальные сети",
+                "description": "Позволяет авторизовать пользователя через некоторые социальные сети",
+                "operationId": "0095f8a8662997958527805d12c27324",
+                "parameters": [
+                    {
+                        "name": "provider",
+                        "in": "path",
+                        "description": "Провайдер социальной сети",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/enums.accounts.users.user.social.type"
+                        },
+                        "example": "vk"
+                    }
+                ],
+                "responses": {
+                    "404": {
+                        "description": "Указанный провайдер социальной сети не существует"
+                    },
+                    "200": {
+                        "description": "Данные для авторизации в социальной сети",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.auth.social.login"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/accounts/users/auth/social/authenticate": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Авторизация.СоциальныеСети"
+                ],
+                "summary": "Аутентифицировать пользователя через социальные сети",
+                "description": "Позволяет аутентифицировать авторизованного через социальную сеть пользователя",
+                "operationId": "42e1d4b7dc7676b933bcc6bf6a9109cf",
+                "parameters": [
+                    {
+                        "name": "state",
+                        "in": "query",
+                        "description": "Ключ аутентификации",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "404": {
+                        "description": "Ключ аутентификации не существует или пользователь еще не авторизован"
+                    },
+                    "200": {
+                        "description": "Токен авторизации",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.auth.social.authenticate"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/accounts/users/auth/logout": {
+            "post": {
+                "tags": [
+                    "Аккаунты.Пользователи.Авторизация"
+                ],
+                "summary": "Деавторизация пользователя",
+                "description": "Деавторизовать пользователя",
+                "operationId": "132d66679910512b70001a8bb5f25141",
+                "responses": {
+                    "200": {
+                        "description": "Результат деавторизации",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.auth.logout"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Не удалось деавторизоваться. Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/auth/password/forget": {
+            "post": {
+                "tags": [
+                    "Аккаунты.Пользователи.Авторизация.Пароль"
+                ],
+                "summary": "Восстановление пароля",
+                "description": "Отправление ссылки на восстановление забытого пароля",
+                "operationId": "d549714f7696a9126c11c3254303cbe8",
+                "requestBody": {
+                    "description": "Данные для восстановления",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "email"
+                                ],
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "example": "my_cool_anime_email@example.com"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Письмо отправлено"
+                    }
+                }
+            }
+        },
+        "/accounts/users/auth/password/reset": {
+            "post": {
+                "tags": [
+                    "Аккаунты.Пользователи.Авторизация.Пароль"
+                ],
+                "summary": "Сброс и установка нового пароля",
+                "description": "Сброс и установка нового пароля",
+                "operationId": "96e405c4aad009c4c555165b0657b576",
+                "requestBody": {
+                    "description": "Новые данные пользователя",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "token",
+                                    "password",
+                                    "password_confirmation"
+                                ],
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "example": "token_from_email"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "example": "myNewCoolPassword"
+                                    },
+                                    "password_confirmation": {
+                                        "type": "string",
+                                        "example": "myNewCoolPassword"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Пароль успешно сброшен"
+                    },
+                    "404": {
+                        "description": "Данные не найдены"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                }
+            }
+        },
+        "/accounts/users/me/collections/references/age-ratings": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Коллекции.Справочники"
+                ],
+                "summary": "Список возрастных рейтингов в коллекциях пользователя",
+                "description": "Возвращает список возрастных рейтингов в коллекциях текущего пользователя",
+                "operationId": "8b157a7586e3c56605e42d0d328ad854",
+                "responses": {
+                    "200": {
+                        "description": "Список возрастных рейтингов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.collections.references.ageRatings"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/collections/references/genres": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Коллекции.Справочники"
+                ],
+                "summary": "Список жанров в коллекциях пользователя",
+                "description": "Возвращает список жанров в коллекциях текущего пользователя",
+                "operationId": "cdedb51df9d04015c63f820e18ae98d4",
+                "responses": {
+                    "200": {
+                        "description": "Список жанров",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.collections.references.genres"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/collections/references/types": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Коллекции.Справочники"
+                ],
+                "summary": "Список типов в коллекциях пользователя",
+                "description": "Возвращает список типов в коллекциях текущего пользователя",
+                "operationId": "3bfa46759da920c8dfb3ab23f95b2b83",
+                "responses": {
+                    "200": {
+                        "description": "Список типов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.collections.references.types"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/collections/references/years": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Коллекции.Справочники"
+                ],
+                "summary": "Список годов в коллекциях пользователя",
+                "description": "Возвращает список годов в коллекциях текущего пользователя",
+                "operationId": "7adae426acd92ba3f282eb1cb38ce4c4",
+                "responses": {
+                    "200": {
+                        "description": "Список годов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.collections.references.years"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/collections/ids": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Коллекции"
+                ],
+                "summary": "Список идентификаторов релизов добавленных в коллекции",
+                "description": "Возвращает данные по идентификаторам релизов и типов коллекций авторизованного пользователя",
+                "operationId": "3952a0264ef53d5cebaebac72b70ea2a",
+                "responses": {
+                    "200": {
+                        "description": "Список идентификаторов релизов и типов коллекций",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.collections.ids"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/collections/releases": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Коллекции"
+                ],
+                "summary": "Список релизов добавленных в коллекцию [GET]",
+                "description": "Возвращает данные по релизам из определенной коллекции авторизованного пользователя",
+                "operationId": "ff552f54874b00625454339a7c989109",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.limit"
+                    },
+                    {
+                        "name": "type_of_collection",
+                        "in": "query",
+                        "description": "Тип коллекции",
+                        "required": true,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/enums.accounts.users.user.collection.type"
+                        },
+                        "example": "RATING_DESC"
+                    },
+                    {
+                        "name": "f[genres]",
+                        "in": "query",
+                        "description": "Список идентификаторов жанров",
+                        "required": false,
+                        "example": "15,20"
+                    },
+                    {
+                        "name": "f[types]",
+                        "in": "query",
+                        "description": "Список типов релизов",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                            }
+                        },
+                        "example": [
+                            "TV",
+                            "WEB"
+                        ]
+                    },
+                    {
+                        "name": "f[years]",
+                        "in": "query",
+                        "description": "Минимальный год выхода релиза",
+                        "required": false,
+                        "example": "2016, 2018, 2019"
+                    },
+                    {
+                        "name": "f[search]",
+                        "in": "query",
+                        "description": "Поисковый запрос",
+                        "required": false,
+                        "example": "Мастера меча"
+                    },
+                    {
+                        "name": "f[age_ratings]",
+                        "in": "query",
+                        "description": "Список возрастных рейтингов",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                            }
+                        },
+                        "example": [
+                            "R6_PLUS",
+                            "R12_PLUS"
+                        ]
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.collections.releases"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Коллекции"
+                ],
+                "summary": "Список релизов добавленных в коллекцию [POST]",
+                "description": "Возвращает данные по релизам из определенной коллекции авторизованного пользователя",
+                "operationId": "713f5e158bb307116510418108b79ab2",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "page": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "example": 15
+                                    },
+                                    "type_of_collection": {
+                                        "$ref": "#/components/schemas/enums.accounts.users.user.collection.type"
+                                    },
+                                    "f": {
+                                        "properties": {
+                                            "genres": {
+                                                "description": "Список идентификаторов жанров",
+                                                "type": "string",
+                                                "example": "15,20"
+                                            },
+                                            "types": {
+                                                "description": "Список типов релизов",
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                                                },
+                                                "example": [
+                                                    "TV",
+                                                    "WEB"
+                                                ]
+                                            },
+                                            "years": {
+                                                "description": "Минимальный год выхода релиза",
+                                                "type": "string",
+                                                "example": "2016, 2018, 2019"
+                                            },
+                                            "search": {
+                                                "description": "Поисковый запрос",
+                                                "type": "string",
+                                                "example": "Мастера меча"
+                                            },
+                                            "age_ratings": {
+                                                "description": "Список возрастных рейтингов",
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                                                },
+                                                "example": [
+                                                    "R6_PLUS",
+                                                    "R12_PLUS"
+                                                ]
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "include": {
+                                        "type": "string",
+                                        "example": "id,type.description"
+                                    },
+                                    "exclude": {
+                                        "type": "string",
+                                        "example": "season.value,description"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Список релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.collections.releases"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/collections": {
+            "post": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Коллекции"
+                ],
+                "summary": "Добавить релизы в коллекции",
+                "description": "Добавляет релизы в соответствующие коллекции авторизованного пользователя",
+                "operationId": "cfc448915a4cb9569951de2b0118db9d",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "required": [
+                                        "release_id",
+                                        "type_of_collection"
+                                    ],
+                                    "properties": {
+                                        "release_id": {
+                                            "type": "number"
+                                        },
+                                        "type_of_collection": {
+                                            "$ref": "#/components/schemas/enums.accounts.users.user.collection.type"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Релизы успешно добавлены в коллекции",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/responses.v1.accounts.users.me.collections.update"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Коллекции"
+                ],
+                "summary": "Удалить релизы из коллекций",
+                "description": "Удаляет релизы из соответствующих коллекций авторизованного пользователя",
+                "operationId": "e7c7a8cb031577e009c11a5128c63191",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "required": [
+                                        "release_id"
+                                    ],
+                                    "properties": {
+                                        "release_id": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Релизы успешно удалены",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/responses.v1.accounts.users.me.collections.delete"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/favorites/references/age-ratings": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное.Справочники"
+                ],
+                "summary": "Список возрастных рейтингов в избранном пользователя",
+                "description": "Возвращает список возрастных рейтингов в избранном текущего пользователя",
+                "operationId": "0079b1666727fca03a65def7b2882ce7",
+                "responses": {
+                    "200": {
+                        "description": "Список возрастных рейтингов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.favorites.references.ageRatings"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/favorites/references/genres": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное.Справочники"
+                ],
+                "summary": "Список жанров в избранном пользователя",
+                "description": "Возвращает список жанров в избранном текущего пользователя",
+                "operationId": "5714dc01fd354c98f2a92e9103f41df3",
+                "responses": {
+                    "200": {
+                        "description": "Список жанров",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.favorites.references.genres"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/favorites/references/sorting": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное.Справочники"
+                ],
+                "summary": "Список опций сортировки в избранном пользователя",
+                "description": "Возвращает список опций сортировки в избранном текущего пользователя",
+                "operationId": "4d9e1c473afa35932a2daf2715d7657c",
+                "responses": {
+                    "200": {
+                        "description": "Список опций сортировки",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.favorites.references.sorting"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/favorites/references/types": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное.Справочники"
+                ],
+                "summary": "Список типов релизов в избранном пользователя",
+                "description": "Возвращает список типов релизов в избранном текущего пользователя",
+                "operationId": "8c7dd07d3f58867144a0fd88482aadac",
+                "responses": {
+                    "200": {
+                        "description": "Список типов релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.favorites.references.types"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/favorites/references/years": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное.Справочники"
+                ],
+                "summary": "Список годов выхода релизов в избранном пользователя",
+                "description": "Возвращает список годов выхода релизов в избранном текущего пользователя",
+                "operationId": "da82e99bb7f630094ff8adb44cc9da5e",
+                "responses": {
+                    "200": {
+                        "description": "Список годов выхода релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.favorites.references.years"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/favorites/ids": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное"
+                ],
+                "summary": "Список идентификаторов релизов добавленных в избранное",
+                "description": "Возвращает данные по идентификаторам релизов из избранного авторизованного пользователя",
+                "operationId": "4706b730c52b2dfad48751c7c10757dc",
+                "responses": {
+                    "200": {
+                        "description": "Список релизов из избранного",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.favorites.ids"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/favorites/releases": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное"
+                ],
+                "summary": "Список релизов в избранном пользователя",
+                "description": "Возвращает данные по релизам из избранного текущего пользователя",
+                "operationId": "5baafd8eec6b0a60ff67a4ac6038f4a9",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.limit"
+                    },
+                    {
+                        "name": "f[years]",
+                        "in": "query",
+                        "description": "Года выхода релиза",
+                        "required": false,
+                        "example": "2016, 2018, 2019"
+                    },
+                    {
+                        "name": "f[types]",
+                        "in": "query",
+                        "description": "Список типов релизов",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                            }
+                        },
+                        "example": [
+                            "TV",
+                            "WEB"
+                        ]
+                    },
+                    {
+                        "name": "f[genres]",
+                        "in": "query",
+                        "description": "Список идентификаторов жанров",
+                        "required": false,
+                        "example": "15,20"
+                    },
+                    {
+                        "name": "f[search]",
+                        "in": "query",
+                        "description": "Поисковый запрос",
+                        "required": false,
+                        "example": "Мастера меча"
+                    },
+                    {
+                        "name": "f[sorting]",
+                        "in": "query",
+                        "description": "Тип сортировки",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/enums.accounts.users.user.favorite.filter.sorting"
+                        },
+                        "example": "RATING_DESC"
+                    },
+                    {
+                        "name": "f[age_ratings]",
+                        "in": "query",
+                        "description": "Список возрастных рейтингов",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                            }
+                        },
+                        "example": [
+                            "R6_PLUS",
+                            "R12_PLUS"
+                        ]
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.favorites.releases"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное"
+                ],
+                "summary": "Список релизов в избранном пользователя",
+                "description": "Возвращает данные по релизам из избранного текущего пользователя",
+                "operationId": "89e379bb7614921658d8cbaa36b8cbdd",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "page": {
+                                        "description": "Страница в выдаче",
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "limit": {
+                                        "description": "Количество релизов в выдаче",
+                                        "type": "integer",
+                                        "example": 15
+                                    },
+                                    "f": {
+                                        "properties": {
+                                            "years": {
+                                                "description": "Года выхода релиза",
+                                                "type": "string",
+                                                "example": "2016, 2018, 2019"
+                                            },
+                                            "types": {
+                                                "description": "Список типов релизов",
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                                                },
+                                                "example": [
+                                                    "TV",
+                                                    "WEB"
+                                                ]
+                                            },
+                                            "genres": {
+                                                "description": "Список идентификаторов жанров",
+                                                "type": "string",
+                                                "example": "15,20"
+                                            },
+                                            "search": {
+                                                "description": "Поисковый запрос",
+                                                "type": "string",
+                                                "example": "Мастера меча"
+                                            },
+                                            "sorting": {
+                                                "$ref": "#/components/schemas/enums.accounts.users.user.favorite.filter.sorting"
+                                            },
+                                            "age_ratings": {
+                                                "description": "Список возрастных рейтингов",
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                                                },
+                                                "example": [
+                                                    "R6_PLUS",
+                                                    "R12_PLUS"
+                                                ]
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "include": {
+                                        "type": "string",
+                                        "example": "id,type.description"
+                                    },
+                                    "exclude": {
+                                        "type": "string",
+                                        "example": "season.value,description"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Список релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.favorites.releases"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/favorites": {
+            "post": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное"
+                ],
+                "summary": "Добавить релизы в избранное",
+                "description": "Добавляет релизы в избранное авторизованного пользователя",
+                "operationId": "7050ee79698aa22d0b67d8d6a1ec5a3b",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "required": [
+                                        "release_id"
+                                    ],
+                                    "properties": {
+                                        "release_id": {
+                                            "type": "integer",
+                                            "example": 9023
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Релизы успешно добавлены в избранное",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.favorites.update"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Избранное"
+                ],
+                "summary": "Удалить релизы из избранного",
+                "description": "Удаляет релизы из избранного авторизованного пользователя",
+                "operationId": "1d04983f0ba43d7c0ad3be4bc567de1f",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "required": [
+                                        "release_id"
+                                    ],
+                                    "properties": {
+                                        "release_id": {
+                                            "type": "integer",
+                                            "example": 9023
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Релизы успешно удалены",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.favorites.delete"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/profile": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Профиль"
+                ],
+                "summary": "Профиль авторизованного пользователя",
+                "description": "Возвращает данные профиля авторизованного пользователя",
+                "operationId": "69fcaa197a8b8cf6c6a4b8dd655ff0f2",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные профиля пользователя",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/models.users.v1.user"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "404": {
+                        "description": "Пользователь не авторизован"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/views/history": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Просмотры"
+                ],
+                "summary": "История просмотренных эпизодов",
+                "description": "Возвращает историю просмотров эпизодов авторизованного пользователя",
+                "operationId": "98e2d85bdf06f190dde743b204aacaa0",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.limit"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "История просмотров",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.views.history"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/accounts/users/me/views/timecodes": {
+            "get": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Просмотры"
+                ],
+                "summary": "Таймкоды просмотренных эпизодов",
+                "description": "Возвращает таймкоды по прогрессу просмотренных эпизодов",
+                "operationId": "8c43236d8913f7775c5c4781ed2a1aff",
+                "parameters": [
+                    {
+                        "name": "since",
+                        "in": "query",
+                        "description": "Возвращает только таймкоды, которые были добавлены после указанного времени (в iso формате)",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "example": "2025-05-12T07:20:50.52Z"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список таймкодов просмотренных эпизодов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/responses.v1.accounts.users.me.views.timecodes"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Просмотры"
+                ],
+                "summary": "Обновление таймкодов прогресса просмотренного эпизода",
+                "description": "Обновляет таймкоды просмотренных эпизодов",
+                "operationId": "de259a20def1fb0f5237f3f3ceb477ea",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "required": [
+                                        "time",
+                                        "is_watched",
+                                        "release_episode_id"
+                                    ],
+                                    "properties": {
+                                        "time": {
+                                            "type": "number",
+                                            "example": 743.5
+                                        },
+                                        "is_watched": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "release_episode_id": {
+                                            "type": "string",
+                                            "format": "uuid",
+                                            "maxLength": 36,
+                                            "example": "68d4d5c5-e3d5-419f-a21c-c511b6b251f5"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Таймкоды просмотренных эпизодов обновлены успешно"
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Аккаунты.Пользователи.Мое.Просмотры"
+                ],
+                "summary": "Удаление таймкодов просмотра эпизодов",
+                "description": "Удаляет данные по таймкодам просмотров для указанных эпизодов",
+                "operationId": "04d4073f12d50d4998b33ce7bbc94d8b",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "required": [
+                                        "release_episode_id"
+                                    ],
+                                    "properties": {
+                                        "release_episode_id": {
+                                            "type": "string",
+                                            "format": "uuid",
+                                            "maxLength": 36,
+                                            "example": "9c5f39e1-56dd-4d44-950a-e1a4201426a4"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Таймкоды просмотренных эпизодов удалены успешно"
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/ads/vasts": {
+            "get": {
+                "tags": [
+                    "Реклама.Vasts"
+                ],
+                "summary": "Список возможных VAST реклам",
+                "description": "Возвращает список со всеми доступными для использования VAST кампаниями",
+                "operationId": "2e32c1bf877c7667ffce578a6f3043b6",
+                "responses": {
+                    "200": {
+                        "description": "Vasts",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.ads.vasts"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ads/vasts/chain": {
+            "get": {
+                "tags": [
+                    "Реклама.Vasts"
+                ],
+                "summary": "VAST XML с цепочкой реклам",
+                "description": "Возвращает XML страницу со всеми доступными для использования VAST кампаниями",
+                "operationId": "48eb9056bf5bd8d6b6d24077c1bb3471",
+                "responses": {
+                    "200": {
+                        "description": "XML VAST",
+                        "content": {
+                            "application/xml": {}
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/catalog/releases": {
+            "get": {
+                "tags": [
+                    "Аниме.Каталог"
+                ],
+                "summary": "Список релизов в каталоге",
+                "description": "Возвращает список релизов по заданными параметрам",
+                "operationId": "deb730a26ed7580e04c822a12b782831",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.limit"
+                    },
+                    {
+                        "name": "f[genres]",
+                        "in": "query",
+                        "description": "Список идентификаторов жанров",
+                        "required": false,
+                        "example": "15,20"
+                    },
+                    {
+                        "name": "f[types]",
+                        "in": "query",
+                        "description": "Список типов релизов",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                            }
+                        },
+                        "example": [
+                            "TV",
+                            "WEB"
+                        ]
+                    },
+                    {
+                        "name": "f[seasons]",
+                        "in": "query",
+                        "description": "Список сезонов релизов",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/enums.anime.releases.release.season"
+                            }
+                        },
+                        "example": [
+                            "winter",
+                            "autumn"
+                        ]
+                    },
+                    {
+                        "name": "f[years][from_year]",
+                        "in": "query",
+                        "description": "Минимальный год выхода релиза",
+                        "required": false,
+                        "example": "2016"
+                    },
+                    {
+                        "name": "f[years][to_year]",
+                        "in": "query",
+                        "description": "Максимальный год выхода релиза",
+                        "required": false,
+                        "example": "2020"
+                    },
+                    {
+                        "name": "f[search]",
+                        "in": "query",
+                        "description": "Поиск запрос",
+                        "required": false,
+                        "example": "Мастера меча"
+                    },
+                    {
+                        "name": "f[sorting]",
+                        "in": "query",
+                        "description": "Тип сортировки",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/enums.anime.catalog.filter.sorting"
+                        },
+                        "example": "RATING_DESC"
+                    },
+                    {
+                        "name": "f[age_ratings]",
+                        "in": "query",
+                        "description": "Список возрастных рейтингов",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                            }
+                        },
+                        "example": [
+                            "R6_PLUS",
+                            "R12_PLUS"
+                        ]
+                    },
+                    {
+                        "name": "f[publish_statuses]",
+                        "in": "query",
+                        "description": "Список статусов релизов",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/enums.anime.catalog.filter.publishStatus"
+                            }
+                        },
+                        "example": "IS_ONGOING"
+                    },
+                    {
+                        "name": "f[production_statuses]",
+                        "in": "query",
+                        "description": "Список статусов релизов",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/enums.anime.catalog.filter.productionStatus"
+                            }
+                        },
+                        "example": "IS_IN_PRODUCTION"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.catalog.releases"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Аниме.Каталог"
+                ],
+                "summary": "Список релизов в каталоге",
+                "description": "Возвращает список релизов по заданными параметрам",
+                "operationId": "1774e330982ade57101c5af1a263b3ad",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "page": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "example": 15
+                                    },
+                                    "f": {
+                                        "properties": {
+                                            "genres": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "integer"
+                                                },
+                                                "example": [
+                                                    15,
+                                                    20
+                                                ]
+                                            },
+                                            "types": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                                                },
+                                                "example": [
+                                                    "TV",
+                                                    "WEB"
+                                                ]
+                                            },
+                                            "seasons": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/enums.anime.releases.release.season"
+                                                },
+                                                "example": [
+                                                    "winter",
+                                                    "autumn"
+                                                ]
+                                            },
+                                            "years": {
+                                                "properties": {
+                                                    "from_year": {
+                                                        "type": "integer",
+                                                        "example": 2016
+                                                    },
+                                                    "to_year": {
+                                                        "type": "integer",
+                                                        "example": 2020
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "search": {
+                                                "type": "string",
+                                                "example": "Мастера меча"
+                                            },
+                                            "sorting": {
+                                                "$ref": "#/components/schemas/enums.anime.catalog.filter.sorting"
+                                            },
+                                            "age_ratings": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                                                },
+                                                "example": [
+                                                    "R6_PLUS",
+                                                    "R12_PLUS"
+                                                ]
+                                            },
+                                            "publish_statuses": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/enums.anime.catalog.filter.publishStatus"
+                                                },
+                                                "example": [
+                                                    "IS_ONGOING"
+                                                ]
+                                            },
+                                            "production_statuses": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/enums.anime.catalog.filter.productionStatus"
+                                                },
+                                                "example": [
+                                                    "IS_IN_PRODUCTION"
+                                                ]
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "include": {
+                                        "type": "string",
+                                        "example": "id,type.description"
+                                    },
+                                    "exclude": {
+                                        "type": "string",
+                                        "example": "season.value,description"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Список релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.catalog.releases"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                }
+            }
+        },
+        "/anime/catalog/references/age-ratings": {
+            "get": {
+                "tags": [
+                    "Аниме.Каталог.Справочники"
+                ],
+                "summary": "Список возрастных рейтингов в каталоге",
+                "description": "Возвращает список возможных возрастных рейтингов в каталоге",
+                "operationId": "7ccd6ec065f6a366883534288e06b946",
+                "responses": {
+                    "200": {
+                        "description": "Список возрастных рейтингов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.catalog.references.ageRatings"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/catalog/references/genres": {
+            "get": {
+                "tags": [
+                    "Аниме.Каталог.Справочники"
+                ],
+                "summary": "Список жанров в каталоге",
+                "description": "Возвращает список всех жанров в каталоге",
+                "operationId": "0849587143559ca91b030ecce1b78924",
+                "responses": {
+                    "200": {
+                        "description": "Список жанров",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.catalog.references.genres"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/catalog/references/production-statuses": {
+            "get": {
+                "tags": [
+                    "Аниме.Каталог.Справочники"
+                ],
+                "summary": "Список возможных статусов озвучки релиза в каталоге",
+                "description": "Возвращает список возможных статусов озвучки релиза в каталоге",
+                "operationId": "48840b125443cfd04e9def7e82332c74",
+                "responses": {
+                    "200": {
+                        "description": "Список статусов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.catalog.references.productionStatuses"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/catalog/references/publish-statuses": {
+            "get": {
+                "tags": [
+                    "Аниме.Каталог.Справочники"
+                ],
+                "summary": "Список возможных статусов выхода релиза в каталоге",
+                "description": "Возвращает список возможных статусов выхода релиза в каталоге",
+                "operationId": "b05b5536b808dab15831b8ceb0b07b3e",
+                "responses": {
+                    "200": {
+                        "description": "Список статусов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.catalog.references.publishStatuses"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/catalog/references/seasons": {
+            "get": {
+                "tags": [
+                    "Аниме.Каталог.Справочники"
+                ],
+                "summary": "Список сезонов релиза в каталоге",
+                "description": "Возвращает список возможных сезонов релизов в каталоге",
+                "operationId": "02c7342e6e3681bd3e68185ed969aef2",
+                "responses": {
+                    "200": {
+                        "description": "Список сезонов релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.catalog.references.seasons"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/catalog/references/sorting": {
+            "get": {
+                "tags": [
+                    "Аниме.Каталог.Справочники"
+                ],
+                "summary": "Список возможных типов сортировок в каталоге",
+                "description": "Возвращает список возможных типов сортировок в каталоге",
+                "operationId": "7d515de59290b809d09c1e61804c7dfd",
+                "responses": {
+                    "200": {
+                        "description": "Список типов сортировок",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.catalog.references.sorting"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/catalog/references/types": {
+            "get": {
+                "tags": [
+                    "Аниме.Каталог.Справочники"
+                ],
+                "summary": "Список типов релизов в каталоге",
+                "description": "Возвращает список возможных типов релизов в каталоге",
+                "operationId": "00815d61be831012848cb3f964a73701",
+                "responses": {
+                    "200": {
+                        "description": "Список типов релизов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.catalog.references.types"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/catalog/references/years": {
+            "get": {
+                "tags": [
+                    "Аниме.Каталог.Справочники"
+                ],
+                "summary": "Список годов в каталоге",
+                "description": "Возвращает список годов в каталоге",
+                "operationId": "107dd05a40cd2fcfb05ce6f2c9e587b8",
+                "responses": {
+                    "200": {
+                        "description": "Список годов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.catalog.references.years"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/franchises": {
+            "get": {
+                "tags": [
+                    "Аниме.Франшизы"
+                ],
+                "summary": "Получить список франшиз",
+                "description": "Возвращает список франшиз.",
+                "operationId": "4bfab3225e23cca7cce5c8e932d261be",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список франшиз",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.franchises"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/franchises/{franchiseId}": {
+            "get": {
+                "tags": [
+                    "Аниме.Франшизы"
+                ],
+                "summary": "Получить франшизу",
+                "description": "Возвращает данные франшизы",
+                "operationId": "70ff1847fe22225d4cae12ad31075057",
+                "parameters": [
+                    {
+                        "name": "franchiseId",
+                        "in": "path",
+                        "description": "ID франшизы",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные франшизы",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.franchise"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/franchises/random": {
+            "get": {
+                "tags": [
+                    "Аниме.Франшизы"
+                ],
+                "summary": "Получить список случайных франшиз",
+                "description": "Возвращает список случайных франшиз.",
+                "operationId": "8cad50ab682ef2cb29271df2ba543628",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Количество случайных франшиз в выдаче",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 4
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список франшиз",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.franchises.random"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/franchises/release/{releaseId}": {
+            "get": {
+                "tags": [
+                    "Аниме.Франшизы"
+                ],
+                "summary": "Получить список франшиз для релиза",
+                "description": "Возвращает список франшиз, в которых участвует релиз",
+                "operationId": "d27fdeccbad6ce91c882fd615561a4ad",
+                "parameters": [
+                    {
+                        "name": "releaseId",
+                        "in": "path",
+                        "description": "ID релиза",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список франшиз релиза",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.franchises.byRelease"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/genres": {
+            "get": {
+                "tags": [
+                    "Аниме.Жанры"
+                ],
+                "summary": "Список всех жанров",
+                "description": "Возвращает список всех жанров",
+                "operationId": "c674398f4cecb9b21a2d7743b16bd4d5",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список доступных жанров",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.genres"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/genres/{genreId}": {
+            "get": {
+                "tags": [
+                    "Аниме.Жанры"
+                ],
+                "summary": "Данные по жанру",
+                "description": "Возвращает данные по жанру",
+                "operationId": "8276762d056f3ccc731848b30a89dc7a",
+                "parameters": [
+                    {
+                        "name": "genreId",
+                        "in": "path",
+                        "description": "ID Жанра",
+                        "required": true,
+                        "example": 15
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по жанру",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.genres.item"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/genres/random": {
+            "get": {
+                "tags": [
+                    "Аниме.Жанры"
+                ],
+                "summary": "Список случайных жанров",
+                "description": "Возвращает список случайных жанров",
+                "operationId": "9822b098b63cec6ffbd72c091251d9d1",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Количество жанров в выдаче",
+                        "required": false,
+                        "example": 8
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список доступных жанров",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.genres.list"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/genres/{genreId}/releases": {
+            "get": {
+                "tags": [
+                    "Аниме.Жанры"
+                ],
+                "summary": "Список релизов жанра",
+                "description": "Возвращает список всех релизов жанра",
+                "operationId": "3e7da8fb153756860d8739524f021926",
+                "parameters": [
+                    {
+                        "name": "genreId",
+                        "in": "path",
+                        "description": "ID Жанра",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 15
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.limit"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список релизов жанра",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.genres.releases"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/releases/latest": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы"
+                ],
+                "summary": "Последние релизы",
+                "description": "Возвращает данные по последним релизам",
+                "operationId": "da7be4d3e8d38a49fcf71358df5c0a76",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Количество последних релизов в выдаче",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 14
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по релизам",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.releases.latest"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                }
+            }
+        },
+        "/anime/releases/random": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы"
+                ],
+                "summary": "Данные по случайным релизам",
+                "description": "Возвращает данные по случайным релизам",
+                "operationId": "9eb40a19816cdbb7621cb40d6c8eef3b",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Количество случайных релизов",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по релизам",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.releases.random"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/releases/recommended": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы"
+                ],
+                "summary": "Данные по рекомендованным релизам",
+                "description": "Возвращает данные по рекомендованным релизам",
+                "operationId": "990d70067d30af5eda130e840fcef7ac",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Количество рекомендованных релизов",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    },
+                    {
+                        "name": "release_id",
+                        "in": "query",
+                        "description": "Идентификатор релиза, для которого рекомендуем",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 9246
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по релизам",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.releases.recommended"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                }
+            }
+        },
+        "/anime/releases/list": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы"
+                ],
+                "summary": "Данные по списку релизов",
+                "description": "Возвращает данные по списку релизов",
+                "operationId": "6efff710532e9015d91227fdb616faeb",
+                "parameters": [
+                    {
+                        "name": "ids",
+                        "in": "query",
+                        "description": "Список ID релизов",
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "example": [
+                                9951,
+                                9433,
+                                5692
+                            ]
+                        }
+                    },
+                    {
+                        "name": "aliases",
+                        "in": "query",
+                        "description": "Список alias релизов",
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "example": [
+                                "darling-in-the-franxx"
+                            ]
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.limit"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по релизу",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.releases.list"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                }
+            }
+        },
+        "/anime/releases/{idOrAlias}": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы"
+                ],
+                "summary": "Данные по релизу",
+                "description": "Возвращает данные по релизу",
+                "operationId": "1a04f3ab108f6960aacb815ecabe29d2",
+                "parameters": [
+                    {
+                        "name": "idOrAlias",
+                        "in": "path",
+                        "description": "id или alias релиза",
+                        "required": true
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по релизу",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.releases.release"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Релиз не найден"
+                    }
+                }
+            }
+        },
+        "/anime/releases/{idOrAlias}/members": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы"
+                ],
+                "summary": "Список участников, которые работали над релизом",
+                "description": "Возвращает данные по участникам релиза",
+                "operationId": "073e49978330ed579e84cc9deb3ba3e6",
+                "parameters": [
+                    {
+                        "name": "idOrAlias",
+                        "in": "path",
+                        "description": "id или alias релиза",
+                        "required": true,
+                        "example": "4754"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по участникам в релизе",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.releases.release.members"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Релиз не найден"
+                    }
+                }
+            }
+        },
+        "/anime/releases/{idOrAlias}/episodes/timecodes": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы"
+                ],
+                "summary": "Данные по таймкодам просмотра эпизодов релиза",
+                "description": "Возвращает данные по всем существующим таймкодам просмотра эпизодов релиза. Имеет 1-2-x минутный кэш.",
+                "operationId": "ca61988f225283fc8a0db99f4f4cfab4",
+                "parameters": [
+                    {
+                        "name": "idOrAlias",
+                        "in": "path",
+                        "description": "id или alias релиза",
+                        "required": true,
+                        "example": "4754"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по просмотру пользователем эпизодов релиза",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.releases.release.episodes.timecodes"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "404": {
+                        "description": "Релиз не найден"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/anime/releases/episodes/{releaseEpisodeId}": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы.Эпизоды"
+                ],
+                "summary": "Данные по эпизоду",
+                "description": "Возвращает данные по эпизоду",
+                "operationId": "d5f0cbb2ce401655a7af10ca7b50eb41",
+                "parameters": [
+                    {
+                        "name": "releaseEpisodeId",
+                        "in": "path",
+                        "description": "Идентификатор эпизода",
+                        "required": true,
+                        "example": "cf31fe87-fad8-11eb-b2fa-0242ac120004"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по эпизоду",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.releases.episode"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Эпизод не найден"
+                    }
+                }
+            }
+        },
+        "/anime/releases/episodes/{releaseEpisodeId}/timecode": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы.Эпизоды"
+                ],
+                "summary": "Данные по просмотру эпизода",
+                "description": "Возвращает данные по просмотру указанного эпизода авторизованным пользователем. Имеет 1-2-x минутный кэш.",
+                "operationId": "3983ade6cbabc60d428294310a365755",
+                "parameters": [
+                    {
+                        "name": "releaseEpisodeId",
+                        "in": "path",
+                        "description": "Идентификатор эпизода",
+                        "required": true,
+                        "example": "cf31fe87-fad8-11eb-b2fa-0242ac120004"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по просмотру эпизода",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.releases.episode.timecode"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Необходимо авторизоваться"
+                    },
+                    "404": {
+                        "description": "Данные по просмотру эпизода не найдены"
+                    }
+                },
+                "security": [
+                    {
+                        "sessionToken": []
+                    }
+                ]
+            }
+        },
+        "/anime/schedule/now": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы.РасписаниеРелизов"
+                ],
+                "summary": "Данные по расписанию релизов на текущую дату",
+                "description": "Возвращает список релизов в расписании на текущую дату",
+                "operationId": "2050390fd4fc22b85e05f08f5d9fdf4c",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по релизам в расписании",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.schedule.now"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/schedule/week": {
+            "get": {
+                "tags": [
+                    "Аниме.Релизы.РасписаниеРелизов"
+                ],
+                "summary": "Данные по расписанию релизов на текущую неделю",
+                "description": "Возвращает список релизов в расписании на текущую неделю",
+                "operationId": "210dca9590f9b5be1dbef022cdb2221d",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по релизам в расписании",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.anime.schedule.week"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/torrents": {
+            "get": {
+                "tags": [
+                    "Аниме.Торренты"
+                ],
+                "summary": "Данные по торрентам",
+                "description": "Возвращает данные по последним торрентам",
+                "operationId": "fcca810f1ea3f9fbd7de393b7a6ccd1b",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.pagination.parameters.limit"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по торренту",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.torrents"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/commons.v1.http.responses.422"
+                    }
+                }
+            }
+        },
+        "/anime/torrents/{hashOrId}": {
+            "get": {
+                "tags": [
+                    "Аниме.Торренты"
+                ],
+                "summary": "Данные по торренту",
+                "description": "Возвращает данные по торренту",
+                "operationId": "a55686f9bd5cdcaf372a85f3ec2fc65c",
+                "parameters": [
+                    {
+                        "name": "hashOrId",
+                        "in": "path",
+                        "description": "Hash или ID торрента",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по торренту",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.torrent"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Не удалось найти торрент по такому hash значению"
+                    }
+                }
+            }
+        },
+        "/anime/torrents/{hashOrId}/file": {
+            "get": {
+                "tags": [
+                    "Аниме.Торренты"
+                ],
+                "summary": "Торрент-файл по его hash или id",
+                "description": "Возвращает торрент-файл",
+                "operationId": "0d2789b05c70d7a360902559c116e4b4",
+                "parameters": [
+                    {
+                        "name": "hashOrId",
+                        "in": "path",
+                        "description": "Hash или ID торрента",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "pk",
+                        "in": "query",
+                        "description": "passkey пользователя. Оставьте пустым для собственного pk (если аутентифицирован)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Торрент файл",
+                        "content": {
+                            "application/x-bittorrent": {}
+                        }
+                    },
+                    "404": {
+                        "description": "Не удалось найти торрент по такому hash значению"
+                    }
+                }
+            }
+        },
+        "/anime/torrents/release/{releaseId}": {
+            "get": {
+                "tags": [
+                    "Аниме.Торренты"
+                ],
+                "summary": "Данные по торрентам для релиза",
+                "description": "Возвращает данные по торрентам релиза",
+                "operationId": "520cfcb16987b608d2965d42df8d3010",
+                "parameters": [
+                    {
+                        "name": "releaseId",
+                        "in": "path",
+                        "description": "ID релиза",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 4754
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Данные по торрентам",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.anime.torrents.releaseTorrents"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Не удалось найти релиз с таким ID"
+                    }
+                }
+            }
+        },
+        "/anime/torrents/rss": {
+            "get": {
+                "tags": [
+                    "Аниме.Торренты"
+                ],
+                "summary": "RSS лента последних торрентов",
+                "description": "Возвращает данные по последним торрентам в виде XML документа",
+                "operationId": "530df7fab8c5f401c1827acf9de7a991",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Количество торрентов в выдаче. По умолчанию 10",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "pk",
+                        "in": "query",
+                        "description": "Пользовательский passkey. Персонализирует ссылки на торренты для учета статистики",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "XML документ",
+                        "content": {
+                            "application/xml": {}
+                        }
+                    }
+                }
+            }
+        },
+        "/anime/torrents/rss/release/{releaseId}": {
+            "get": {
+                "tags": [
+                    "Аниме.Торренты"
+                ],
+                "summary": "RSS лента торрентов релиза",
+                "description": "Возвращает данные по торрентам релиза в виде RSS ленты",
+                "operationId": "b0a67aeaf4fb4d0e67b47452c1f71161",
+                "parameters": [
+                    {
+                        "name": "releaseId",
+                        "in": "path",
+                        "description": "ID релиза",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 4754
+                        }
+                    },
+                    {
+                        "name": "pk",
+                        "in": "query",
+                        "description": "Пользовательский passkey. Персонализирует ссылки на торренты для учета статистики",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "XML документ",
+                        "content": {
+                            "application/xml": {}
+                        }
+                    }
+                }
+            }
+        },
+        "/app/search/releases": {
+            "get": {
+                "tags": [
+                    "Приложение.Поиск"
+                ],
+                "summary": "Поиск релизов",
+                "description": "Возвращает данные по релизам, которые удовлетворяют поисковому запросу",
+                "operationId": "bdc9c56b8c4464f3629eaccabac8db20",
+                "parameters": [
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "description": "Поисковая строка",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Найденные релизы",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.app.search.releases"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/app/status": {
+            "get": {
+                "tags": [
+                    "Приложение.Статус"
+                ],
+                "summary": "Статус API",
+                "description": "Возвращает информацию о статусе API",
+                "operationId": "5523c4a4ef98641efa267e67891c7762",
+                "responses": {
+                    "200": {
+                        "description": "Успешный ответ",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.app.status"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/media/promotions": {
+            "get": {
+                "tags": [
+                    "Медиа.Промо"
+                ],
+                "summary": "Список промо-материалов",
+                "description": "Возвращает список промо-материалов или рекламные кампании в случайном порядке",
+                "operationId": "a9e450153c7cb6120c51bb4737c830f8",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Промо-материал",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.media.promotions"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/media/videos": {
+            "get": {
+                "tags": [
+                    "Медиа.Видеоконтент"
+                ],
+                "summary": "Список видео-роликов",
+                "description": "Возвращает список последних видео-роликов",
+                "operationId": "13324a2b1d96abfe1fbb72686b164afd",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Количество роликов в выдаче",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Список видео-роликов",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.v1.media.videos"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teams/": {
+            "get": {
+                "tags": [
+                    "Команды"
+                ],
+                "summary": "Список команд АниЛибрии",
+                "description": "Возвращает список всех команд",
+                "operationId": "b8116e18f2ffc250bda35faa120bbe2d",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Команды",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.teams"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teams/roles": {
+            "get": {
+                "tags": [
+                    "Команды"
+                ],
+                "summary": "Список ролей",
+                "description": "Возвращает список всех ролей в командах",
+                "operationId": "a9c6af5eb738ffb0b0ffe2827ab8a66a",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Роли в командах",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.teams.roles"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teams/users": {
+            "get": {
+                "tags": [
+                    "Команды"
+                ],
+                "summary": "Список анилибрийцов",
+                "description": "Возвращает список всех анилибрийцов с указанием команды и своих ролей",
+                "operationId": "7595de64ca791916074cb8c193a21604",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.include"
+                    },
+                    {
+                        "$ref": "#/components/parameters/commons.v1.utils.includeAndExclude.parameters.exclude"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Анилибрийцы",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.api.v1.teams.users"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "commons.v1.http.responses.422.content": {
+                "description": "Ошибка валидации  параметров",
+                "properties": {
+                    "errors": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "type": "object",
+                "example": {
+                    "errors": {
+                        "parameter1": [
+                            "Поле parameter1 обязательно для заполнения",
+                            "Поле parameter1 должно быть числом"
+                        ],
+                        "parameter2": [
+                            "Поле parameter2 должно быть строкой"
+                        ]
+                    }
+                }
+            },
+            "commons.v1.models.components.image": {
+                "properties": {
+                    "preview": {
+                        "description": "Ссылка на изображение",
+                        "type": "string",
+                        "example": "/...GoH5bzLFS7A21DzacgUApScj7qJY1iMz.(jpg|webp)"
+                    },
+                    "thumbnail": {
+                        "description": "Ссылка на изображение",
+                        "type": "string",
+                        "example": "/.../GoH5bzLFS7A21DzacgUApScj7qJY1iMz.(jpg|webp)"
+                    }
+                },
+                "type": "object"
+            },
+            "commons.v1.models.components.image.withOptimized": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image"
+                    },
+                    {
+                        "properties": {
+                            "optimized": {
+                                "$ref": "#/components/schemas/commons.v1.models.components.image"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "commons.v1.utils.pagination.schemes.meta": {
+                "properties": {
+                    "pagination": {
+                        "properties": {
+                            "total": {
+                                "type": "integer",
+                                "example": "1704"
+                            },
+                            "count": {
+                                "type": "integer",
+                                "example": "10"
+                            },
+                            "per_page": {
+                                "type": "integer",
+                                "example": "10"
+                            },
+                            "current_page": {
+                                "type": "integer",
+                                "example": "5"
+                            },
+                            "total_pages": {
+                                "type": "integer",
+                                "example": "171"
+                            },
+                            "links": {
+                                "properties": {
+                                    "previous": {
+                                        "type": "string",
+                                        "example": "/api/version/path-to-resource?page=1"
+                                    },
+                                    "next": {
+                                        "type": "string",
+                                        "example": "/api/version/path-to-resource?page=3"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.api.v1.accounts.otp.login": {
+                "title": "responses.api.v1.accounts.otp.login",
+                "properties": {
+                    "token": {
+                        "type": "string",
+                        "example": "eyJpdiI6ImJDeElkYzliNFBDb2VFMDdtdnZpdVE9PSIsInZhbHVlIjoiM0Y5SnVINno3NndBbUcvU2NPVjJhMmhTMllJdWd4WUlF=="
+                    }
+                },
+                "type": "object"
+            },
+            "responses.api.v1.accounts.otp.get": {
+                "title": "responses.api.v1.accounts.otp.get",
+                "properties": {
+                    "otp": {
+                        "$ref": "#/components/schemas/models.accounts.otp.v1.otp"
+                    },
+                    "remaining_time": {
+                        "type": "integer",
+                        "example": 120
+                    }
+                },
+                "type": "object"
+            },
+            "models.accounts.otp.v1.otp": {
+                "title": "models.accounts.otp.v1.otp",
+                "description": "Данные по OTP коду",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "example": "058701"
+                    },
+                    "user_id": {
+                        "type": "integer",
+                        "example": 1337
+                    },
+                    "device_id": {
+                        "type": "string",
+                        "example": "n702175b-fa52-5251-a39z-d1f4af0w1cak"
+                    },
+                    "expired_at": {
+                        "description": "Срок действия кода",
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2021-09-28T19:40:26+00:00"
+                    }
+                },
+                "type": "object"
+            },
+            "enums.accounts.users.user.social.type": {
+                "title": "enums.accounts.users.user.social.type",
+                "type": "string",
+                "enum": [
+                    "vk",
+                    "google",
+                    "patreon",
+                    "discord"
+                ]
+            },
+            "enums.accounts.users.user.collection.type": {
+                "title": "enums.accounts.users.user.collection.type",
+                "description": "Тип коллекции",
+                "type": "string",
+                "enum": [
+                    "PLANNED",
+                    "WATCHED",
+                    "WATCHING",
+                    "POSTPONED",
+                    "ABANDONED"
+                ],
+                "example": "PLANNED"
+            },
+            "enums.accounts.users.user.favorite.filter.sorting": {
+                "title": "enums.accounts.users.user.favorite.filter.sorting",
+                "type": "string",
+                "enum": [
+                    "CREATED_AT_DESC",
+                    "CREATED_AT_ASC",
+                    "FRESH_AT_DESC",
+                    "FRESH_AT_ASC",
+                    "RATING_DESC",
+                    "RATING_ASC",
+                    "YEAR_DESC",
+                    "YEAR_ASC"
+                ]
+            },
+            "responses.api.v1.accounts.users.me.collections.references.ageRatings": {
+                "title": "responses.api.v1.accounts.users.me.collections.references.ageRatings",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                        },
+                        "label": {
+                            "description": "Название типа",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "Описание типа",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.accounts.users.me.collections.references.genres": {
+                "title": "responses.api.v1.accounts.users.me.collections.references.genres",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "id": {
+                            "description": "Идентификатор жанра",
+                            "type": "integer"
+                        },
+                        "name": {
+                            "description": "Название жанра",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.accounts.users.me.collections.references.types": {
+                "title": "responses.api.v1.accounts.users.me.collections.references.types",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                        },
+                        "description": {
+                            "description": "Описание типа",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.accounts.users.me.collections.references.years": {
+                "title": "responses.api.v1.accounts.users.me.collections.references.years",
+                "type": "array",
+                "items": {
+                    "description": "Год",
+                    "type": "integer"
+                },
+                "example": [
+                    2020,
+                    2021,
+                    2022,
+                    2023
+                ]
+            },
+            "responses.v1.accounts.users.collections.releases": {
+                "title": "responses.v1.accounts.users.collections.releases",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                },
+                                {
+                                    "properties": {
+                                        "genres": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/models.anime.genres.v1.genre"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "properties": {
+                                        "episodes": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/models.anime.releases.v1.release.episode"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/commons.v1.utils.pagination.schemes.meta"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.api.v1.accounts.users.me.favorites.references.ageRatings": {
+                "title": "responses.api.v1.accounts.users.me.favorites.references.ageRatings",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                        },
+                        "label": {
+                            "description": "Название рейтинга",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "Описание рейтинга",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.accounts.users.me.favorites.references.genres": {
+                "title": "responses.api.v1.accounts.users.me.favorites.references.genres",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "id": {
+                            "description": "Идентификатор жанра",
+                            "type": "integer"
+                        },
+                        "name": {
+                            "description": "Название жанра",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.accounts.users.me.favorites.references.sorting": {
+                "title": "responses.api.v1.accounts.users.me.favorites.references.sorting",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.accounts.users.user.favorite.filter.sorting"
+                        },
+                        "label": {
+                            "description": "Название опции сортировки",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "Описание опции сортировки",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.accounts.users.me.favorites.references.types": {
+                "title": "responses.api.v1.accounts.users.me.favorites.references.types",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                        },
+                        "description": {
+                            "description": "Описание типа релиза",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.accounts.users.me.favorites.references.years": {
+                "title": "responses.api.v1.accounts.users.me.favorites.references.years",
+                "type": "array",
+                "items": {
+                    "description": "Год выхода релиза",
+                    "type": "integer"
+                },
+                "example": [
+                    2020,
+                    2021,
+                    2022,
+                    2023
+                ]
+            },
+            "responses.v1.accounts.users.me.favorites.releases": {
+                "title": "responses.v1.accounts.users.me.favorites.releases",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                },
+                                {
+                                    "properties": {
+                                        "genres": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/models.anime.genres.v1.genre"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "properties": {
+                                        "episodes": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/models.anime.releases.v1.release.episode"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/commons.v1.utils.pagination.schemes.meta"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.v1.accounts.users.me.views.history": {
+                "title": "responses.v1.accounts.users.me.views.history",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/models.accounts.users.v1.user.view"
+                                },
+                                {
+                                    "properties": {
+                                        "release_episode": {
+                                            "type": "object",
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/components/schemas/models.anime.releases.v1.release.episode"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "release": {
+                                                            "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/commons.v1.utils.pagination.schemes.meta"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.v1.accounts.users.auth.login": {
+                "title": "responses.v1.accounts.users.auth.login",
+                "properties": {
+                    "token": {
+                        "type": "string",
+                        "example": "eyJpdiI6IjlhZTBTaU9QZ0pUQ0E5YzZzYzhWRWc9PSIsInZhbHVlIjoiSFZaVHF6Sm45UVBCVk13U1hFYWpRdm1IL0xWWTFpTCtKUUpacDhqSk9LZEY1N0R1MURsN3A5VWRvUFp2OU5YYSIsIm1hYyI6IjUyYTM1NmM5ZGNkNGRiOTFiZmM3Y2FhZmY1ZGQ2MTAzOTc4MDNlMGM2MDg1OWNiMjFlODRiNGIyZGRiNTU1YTIifQ=="
+                    }
+                },
+                "type": "object"
+            },
+            "responses.v1.accounts.users.auth.social.authenticate": {
+                "title": "responses.v1.accounts.users.auth.social.authenticate",
+                "properties": {
+                    "token": {
+                        "description": "JWT токен авторизации",
+                        "type": "string",
+                        "example": "eyJpdiI6IjlhZTBTaU9QZ0pUQ0E5YzZzYzhWRWc9PSIsInZhbHVlIjoiSFZaVHF6Sm45UVBCVk13U1hFYWpRdm1IL0xWWTFpTCtKUUpacDhqSk9LZEY1N0R1MURsN3A5VWRvUFp2OU5YYSIsIm1hYyI6IjUyYTM1NmM5ZGNkNGRiOTFiZmM3Y2FhZmY1ZGQ2MTAzOTc4MDNlMGM2MDg1OWNiMjFlODRiNGIyZGRiNTU1YTIifQ=="
+                    }
+                },
+                "type": "object"
+            },
+            "responses.v1.accounts.users.auth.social.login": {
+                "title": "responses.v1.accounts.users.auth.social.login",
+                "properties": {
+                    "url": {
+                        "description": "Ссылка на oauth авторизацию через указанную социальную сеть",
+                        "type": "string",
+                        "example": "https://oauth.vk.com/authorize?client_id=&redirect_uri=&scope=email&response_type=code&state=9xLcqDvd08tTPODsHAXgcidxOvpg3P7Nuc"
+                    },
+                    "state": {
+                        "description": "Ключ для аутентификации пройденной авторизации",
+                        "type": "string",
+                        "example": "9xLcqDvd08tTPODsHAXgcidxOvpg3P7Nuc"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.v1.accounts.users.auth.logout": {
+                "title": "responses.v1.accounts.users.auth.logout",
+                "properties": {
+                    "token": {
+                        "type": "null",
+                        "example": "null"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.v1.accounts.users.me.collections.delete": {
+                "title": "responses.v1.accounts.users.me.collections.delete",
+                "description": "Результат удаления релизов из коллекций",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.collections.ids.item"
+                }
+            },
+            "responses.api.v1.accounts.users.me.collections.ids": {
+                "title": "responses.api.v1.accounts.users.me.collections.ids",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.collections.ids.item"
+                }
+            },
+            "responses.api.v1.accounts.users.me.collections.ids.item": {
+                "title": "responses.api.v1.accounts.users.me.collections.ids.item",
+                "maxItems": 2,
+                "minItems": 2,
+                "oneOf": [
+                    {
+                        "description": "Идентификатор релиза",
+                        "type": "number",
+                        "example": 8345
+                    },
+                    {
+                        "$ref": "#/components/schemas/enums.accounts.users.user.collection.type"
+                    }
+                ]
+            },
+            "responses.v1.accounts.users.me.collections.update": {
+                "title": "responses.v1.accounts.users.me.collections.update",
+                "description": "Результат добавления релизов в коллекции",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/responses.api.v1.accounts.users.me.collections.ids.item"
+                }
+            },
+            "responses.v1.accounts.users.me.favorites.delete": {
+                "title": "responses.v1.accounts.users.me.favorites.delete",
+                "description": "Список ID релизов, оставшихся в избранном после удаления",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.favorites.ids.item"
+                },
+                "example": [
+                    9021,
+                    9022
+                ]
+            },
+            "responses.v1.accounts.users.me.favorites.ids.item": {
+                "title": "responses.v1.accounts.users.me.favorites.ids.item",
+                "type": "integer",
+                "example": 9023
+            },
+            "responses.v1.accounts.users.me.favorites.ids": {
+                "title": "responses.v1.accounts.users.me.favorites.ids",
+                "description": "Список ID релизов в избранном",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.favorites.ids.item"
+                },
+                "example": [
+                    9023,
+                    9024,
+                    9025
+                ]
+            },
+            "responses.v1.accounts.users.me.favorites.update": {
+                "title": "responses.v1.accounts.users.me.favorites.update",
+                "description": "Список ID релизов в избранном",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.favorites.ids.item"
+                },
+                "example": [
+                    9023,
+                    9024,
+                    9025
+                ]
+            },
+            "responses.v1.accounts.users.me.views.timecodes.item": {
+                "title": "responses.v1.accounts.users.me.views.timecodes.item",
+                "maxItems": 3,
+                "minItems": 3,
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "68d4d5c5-e3d5-419f-a21c-c511b6b251f5"
+                    },
+                    {
+                        "type": "number",
+                        "example": 743
+                    },
+                    {
+                        "type": "boolean",
+                        "example": true
+                    }
+                ]
+            },
+            "responses.v1.accounts.users.me.views.timecodes": {
+                "title": "responses.v1.accounts.users.me.views.timecodes",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/responses.v1.accounts.users.me.views.timecodes.item"
+                }
+            },
+            "models.users.v1.user.session": {
+                "title": "models.users.v1.user.session",
+                "description": "Данные по сессии пользователя",
+                "properties": {
+                    "id": {
+                        "description": "Transform pattern",
+                        "type": "string",
+                        "example": "XbSmRDA95bJXPk3E"
+                    },
+                    "user_id": {
+                        "type": "integer",
+                        "example": 482903
+                    },
+                    "device": {
+                        "description": "Информация об устройстве",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "example": "Macintosh"
+                            },
+                            "version": {
+                                "type": "string",
+                                "example": "10.15"
+                            },
+                            "platform": {
+                                "type": "string",
+                                "example": "Mac OS X"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "browser": {
+                        "description": "Информация о браузере",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "example": "Chrome"
+                            },
+                            "version": {
+                                "type": "string",
+                                "example": "112.0"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "location": {
+                        "description": "Геолокация пользователя",
+                        "properties": {
+                            "country": {
+                                "type": "string",
+                                "example": "Russia"
+                            },
+                            "iso_code": {
+                                "type": "string",
+                                "example": "RU"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "is_mobile": {
+                        "description": "Мобильное устройство",
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "is_desktop": {
+                        "description": "Десктопное устройство",
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "ip_address": {
+                        "description": "IP-адрес",
+                        "type": "string",
+                        "example": "192.168.1.1"
+                    },
+                    "user_agent": {
+                        "description": "User-Agent",
+                        "type": "string",
+                        "example": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+                    },
+                    "is_current": {
+                        "description": "Текущая сессия",
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "last_active": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2024-03-01T12:34:56+00:00"
+                    }
+                },
+                "type": "object"
+            },
+            "models.users.v1.user": {
+                "title": "models.users.v1.user",
+                "description": "Данные по пользователю",
+                "properties": {
+                    "id": {
+                        "description": "Transform pattern",
+                        "type": "integer",
+                        "example": 4837362
+                    },
+                    "login": {
+                        "description": "Отображается только собственный",
+                        "type": "string",
+                        "example": "animeshnik_488"
+                    },
+                    "email": {
+                        "description": "Отображается только собственный",
+                        "type": "string",
+                        "example": "animeshnik_488@protonmail.com"
+                    },
+                    "nickname": {
+                        "type": "string",
+                        "example": "Animeshnik488"
+                    },
+                    "avatar": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    },
+                    "torrents": {
+                        "description": "Данные по торрентам",
+                        "properties": {
+                            "passkey": {
+                                "description": "passkey, отображается только собственный",
+                                "type": "string",
+                                "example": "xBSmRDA95bJXPk3E"
+                            },
+                            "uploaded": {
+                                "description": "Количество отданного, в байтах",
+                                "type": "integer",
+                                "example": 998234623
+                            },
+                            "downloaded": {
+                                "description": "Количество скачанного, в байтах",
+                                "type": "integer",
+                                "example": 2397162874432
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "is_banned": {
+                        "description": "Забанен ли пользоваель в данный момент",
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2019-03-31T20:43:52+00:00"
+                    },
+                    "is_with_ads": {
+                        "description": "Отображение рекламы",
+                        "type": "boolean",
+                        "example": false
+                    }
+                },
+                "type": "object"
+            },
+            "models.accounts.users.v1.user.view": {
+                "title": "models.accounts.users.v1.user.view",
+                "properties": {
+                    "id": {
+                        "description": "ID записи просмотра",
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "time": {
+                        "description": "Таймкод просмотра, в секундах от начала эпизода",
+                        "type": "integer",
+                        "format": "float",
+                        "example": 127.45
+                    },
+                    "user_id": {
+                        "description": "ID пользователя",
+                        "type": "integer",
+                        "example": 42
+                    },
+                    "is_watched": {
+                        "description": "Флаг, просмотрен ли эпизод полностью",
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "updated_at": {
+                        "description": "Дата обновления записи",
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-06-23T14:00:00+00:00"
+                    },
+                    "release_episode_id": {
+                        "description": "ID эпизода релиза",
+                        "type": "string",
+                        "example": "9b5e26ee-598f-4b8b-b77e-188d3e456318"
+                    }
+                },
+                "type": "object"
+            },
+            "enums.ads.banner.placement": {
+                "title": "enums.ads.banner.placement",
+                "description": "Позиции размещения рекламных баннеров",
+                "type": "string",
+                "enum": [
+                    "HOME_SUPPORT",
+                    "RELEASE_SIDEBAR"
+                ]
+            },
+            "models.ads.banners.v1.banner": {
+                "title": "models.ads.banners.v1.banner",
+                "description": "Данные рекламного баннера",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 101
+                    },
+                    "title": {
+                        "type": "string",
+                        "example": "Смотри аниме без рекламы!"
+                    },
+                    "image": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    },
+                    "ad_erid": {
+                        "type": "string",
+                        "example": "CZkqkNu5u8N"
+                    },
+                    "image_url": {
+                        "type": "string",
+                        "example": "https://external.site/banner.jpg"
+                    },
+                    "button_url": {
+                        "type": "string",
+                        "example": "https://aniliberty.top/subscribe"
+                    },
+                    "placement": {
+                        "$ref": "#/components/schemas/enums.ads.banner.placement"
+                    },
+                    "has_overlay": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "button_title": {
+                        "type": "string",
+                        "example": "Подписаться"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Смотри любимые сериалы без ограничений"
+                    },
+                    "ad_company_itn": {
+                        "type": "string",
+                        "example": "7707083893"
+                    },
+                    "ad_company_name": {
+                        "type": "string",
+                        "example": "ООО \"Аниме Медиа Групп\""
+                    }
+                },
+                "type": "object"
+            },
+            "enums.ads.statistics.event.type": {
+                "title": "enums.ads.statistics.event.type",
+                "description": "Типы событий рекламной статистики",
+                "type": "string",
+                "enum": [
+                    "AD_VAST_SHOW",
+                    "AD_VAST_REQUEST",
+                    "AD_BANNER_VIEW",
+                    "AD_BANNER_CLICK",
+                    "MEDIA_PROMOTION_VIEW",
+                    "MEDIA_PROMOTION_CLICK"
+                ]
+            },
+            "responses.api.v1.ads.vasts": {
+                "title": "responses.api.v1.ads.vasts",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.ads.vasts.v1.vast"
+                }
+            },
+            "models.ads.vasts.v1.vast": {
+                "title": "models.ads.vasts.v1.vast",
+                "description": "Данные по рекламе VAST",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "example": "17974e6e-da62-427b-9937-9021cf4cafe4"
+                    },
+                    "url": {
+                        "type": "string",
+                        "example": "https://example.com/vast.xml"
+                    },
+                    "ad_erid": {
+                        "type": "string",
+                        "example": "ERID123456789"
+                    },
+                    "ad_company_itn": {
+                        "type": "string",
+                        "example": "1234567890"
+                    },
+                    "ad_company_name": {
+                        "type": "string",
+                        "example": "Company XYZ"
+                    }
+                },
+                "type": "object"
+            },
+            "enums.anime.catalog.filter.productionStatus": {
+                "title": "enums.anime.catalog.filter.productionStatus",
+                "type": "string",
+                "enum": [
+                    "IS_IN_PRODUCTION",
+                    "IS_NOT_IN_PRODUCTION"
+                ]
+            },
+            "enums.anime.catalog.filter.publishStatus": {
+                "title": "enums.anime.catalog.filter.publishStatus",
+                "type": "string",
+                "enum": [
+                    "IS_ONGOING",
+                    "IS_NOT_ONGOING"
+                ]
+            },
+            "enums.anime.catalog.filter.sorting": {
+                "title": "enums.anime.catalog.filter.sorting",
+                "type": "string",
+                "enum": [
+                    "FRESH_AT_DESC",
+                    "FRESH_AT_ASC",
+                    "RATING_DESC",
+                    "RATING_ASC",
+                    "YEAR_DESC",
+                    "YEAR_ASC"
+                ]
+            },
+            "responses.api.v1.anime.catalog.releases": {
+                "title": "responses.api.v1.anime.catalog.releases",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                },
+                                {
+                                    "properties": {
+                                        "genres": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/models.anime.genres.v1.genre"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/commons.v1.utils.pagination.schemes.meta"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.api.v1.anime.catalog.references.ageRatings": {
+                "title": "responses.api.v1.anime.catalog.references.ageRatings",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                        },
+                        "label": {
+                            "description": "Название типа",
+                            "type": "string",
+                            "example": "PG-17"
+                        },
+                        "description": {
+                            "description": "Описание типа",
+                            "type": "string",
+                            "example": "PG"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.anime.catalog.references.genres": {
+                "title": "responses.api.v1.anime.catalog.references.genres",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "id": {
+                            "description": "ID жанра",
+                            "type": "integer",
+                            "example": 23
+                        },
+                        "name": {
+                            "description": "Название жанра",
+                            "type": "string",
+                            "example": "Мистика"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.anime.catalog.references.productionStatuses": {
+                "title": "responses.api.v1.anime.catalog.references.productionStatuses",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.catalog.filter.productionStatus"
+                        },
+                        "description": {
+                            "description": "Описание статуса",
+                            "type": "string",
+                            "example": "Сейчас в озвучке"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.api.v1.anime.catalog.references.publishStatuses": {
+                "title": "responses.api.v1.anime.catalog.references.publishStatuses",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.catalog.filter.publishStatus"
+                        },
+                        "description": {
+                            "description": "Описание статуса",
+                            "type": "string",
+                            "example": "Онгоинг"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.v1.anime.catalog.references.seasons": {
+                "title": "responses.v1.anime.catalog.references.seasons",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.releases.release.season"
+                        },
+                        "description": {
+                            "description": "Название сезона",
+                            "type": "string",
+                            "example": "Зима"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.v1.anime.catalog.references.sorting": {
+                "title": "responses.v1.anime.catalog.references.sorting",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.catalog.filter.sorting"
+                        },
+                        "label": {
+                            "description": "Название типа",
+                            "type": "string",
+                            "example": "Самый низкий рейтинг"
+                        },
+                        "description": {
+                            "description": "Описание типа",
+                            "type": "string",
+                            "example": "Сначала отобразятся самые непопулярные релизы"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.v1.anime.catalog.references.types": {
+                "title": "responses.v1.anime.catalog.references.types",
+                "type": "array",
+                "items": {
+                    "properties": {
+                        "value": {
+                            "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                        },
+                        "description": {
+                            "description": "Название типа",
+                            "type": "string",
+                            "example": "ТВ"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "responses.v1.anime.catalog.references.years": {
+                "title": "responses.v1.anime.catalog.references.years",
+                "description": "Массив годов",
+                "type": "array",
+                "items": {
+                    "type": "integer"
+                },
+                "example": [
+                    2020,
+                    2021,
+                    2022,
+                    2023
+                ]
+            },
+            "responses.v1.anime.franchises": {
+                "title": "responses.v1.anime.franchises",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.anime.franchises.v1.franchise"
+                }
+            },
+            "responses.v1.anime.franchise": {
+                "title": "responses.v1.anime.franchise",
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/models.anime.franchises.v1.franchise"
+                    },
+                    {
+                        "properties": {
+                            "franchise_releases": {
+                                "type": "array",
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/models.anime.franchises.v1.franchise.release"
+                                        },
+                                        {
+                                            "properties": {
+                                                "release": {
+                                                    "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "responses.v1.anime.franchises.random": {
+                "title": "responses.v1.anime.franchises.random",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.anime.franchises.v1.franchise"
+                }
+            },
+            "responses.v1.anime.franchises.byRelease": {
+                "title": "responses.v1.anime.franchises.byRelease",
+                "type": "array",
+                "items": {
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/models.anime.franchises.v1.franchise"
+                        },
+                        {
+                            "properties": {
+                                "franchise_releases": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/models.anime.franchises.v1.franchise.release"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "release": {
+                                                        "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                }
+            },
+            "models.anime.franchises.v1.franchise.release": {
+                "title": "models.anime.franchises.v1.franchise.release",
+                "description": "Данные по релизам в франшизе",
+                "properties": {
+                    "id": {
+                        "description": "ID связки релиз — франшиза",
+                        "type": "string",
+                        "example": "db1ebabd-b4b8-4391-85f3-79294515641a"
+                    },
+                    "sort_order": {
+                        "description": "Порядок сортировки",
+                        "type": "integer",
+                        "example": 2
+                    },
+                    "release_id": {
+                        "description": "Идентификатор релиза",
+                        "type": "integer",
+                        "example": 9045
+                    },
+                    "franchise_id": {
+                        "description": "Идентификатор франшизы",
+                        "type": "string",
+                        "example": "3f69ea9b-c202-4522-96b9-07a5de8aa963"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.franchises.v1.franchise": {
+                "title": "models.anime.franchises.v1.franchise",
+                "description": "Данные по франшизе",
+                "properties": {
+                    "id": {
+                        "description": "Идентификатор франшизы",
+                        "type": "string",
+                        "example": "116e17d2-e89f-4ffc-bfa4-b45ae4c41e92"
+                    },
+                    "name": {
+                        "description": "Название франшизы (на русском)",
+                        "type": "string",
+                        "example": "Re: Жизнь в другом мире с нуля"
+                    },
+                    "name_english": {
+                        "description": "Название франшизы (на английском)",
+                        "type": "string",
+                        "example": "Re: Zero kara Hajimeru Isekai Seikatsu"
+                    },
+                    "image": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    },
+                    "rating": {
+                        "description": "Рейтинг франшизы",
+                        "type": "number",
+                        "example": 8.45
+                    },
+                    "last_year": {
+                        "description": "Год последнего релиза",
+                        "type": "integer",
+                        "example": 2023
+                    },
+                    "first_year": {
+                        "description": "Год первого релиза",
+                        "type": "integer",
+                        "example": 2010
+                    },
+                    "total_releases": {
+                        "description": "Количество релизов",
+                        "type": "integer",
+                        "example": 10
+                    },
+                    "total_episodes": {
+                        "description": "Общее количество эпизодов",
+                        "type": "integer",
+                        "example": 25
+                    },
+                    "total_duration": {
+                        "description": "Общая длительность франшизы",
+                        "type": "string",
+                        "example": "2 дня 5 часов",
+                        "nullable": true
+                    },
+                    "total_duration_in_seconds": {
+                        "description": "Общая длительность франшизы в секундах",
+                        "type": "integer",
+                        "example": 183600
+                    }
+                },
+                "type": "object"
+            },
+            "responses.api.v1.anime.genres": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.anime.genres.v1.genre"
+                }
+            },
+            "responses.api.v1.anime.genres.item": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/models.anime.genres.v1.genre"
+                    }
+                ]
+            },
+            "responses.api.v1.anime.genres.list": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.anime.genres.v1.genre"
+                }
+            },
+            "responses.api.v1.anime.genres.releases": {
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                        }
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/commons.v1.utils.pagination.schemes.meta"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.genres.v1.genre": {
+                "title": "models.anime.genres.v1.genre",
+                "description": "Данные по жанрам",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 21
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Комедия"
+                    },
+                    "image": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    },
+                    "total_releases": {
+                        "description": "Общее количество релизов в этом жанре",
+                        "type": "integer",
+                        "example": 10
+                    }
+                },
+                "type": "object"
+            },
+            "enums.anime.releases.release.ageRating": {
+                "title": "enums.anime.releases.release.ageRating",
+                "type": "string",
+                "enum": [
+                    "R0_PLUS",
+                    "R6_PLUS",
+                    "R12_PLUS",
+                    "R16_PLUS",
+                    "R18_PLUS"
+                ]
+            },
+            "enums.anime.releases.release.publishDay": {
+                "title": "enums.anime.releases.release.publishDay",
+                "type": "integer",
+                "enum": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ]
+            },
+            "enums.anime.releases.release.season": {
+                "title": "enums.anime.releases.release.season",
+                "type": "string",
+                "enum": [
+                    "winter",
+                    "spring",
+                    "summer",
+                    "autumn"
+                ]
+            },
+            "enums.anime.releases.release.type": {
+                "title": "enums.anime.releases.release.type",
+                "type": "string",
+                "enum": [
+                    "TV",
+                    "ONA",
+                    "WEB",
+                    "OVA",
+                    "OAD",
+                    "MOVIE",
+                    "DORAMA",
+                    "SPECIAL"
+                ]
+            },
+            "enums.anime.releases.release.member.role": {
+                "title": "enums.anime.releases.release.member.role",
+                "description": "Роль участника релиза",
+                "type": "string",
+                "enum": [
+                    "poster",
+                    "timing",
+                    "voicing",
+                    "editing",
+                    "decorating",
+                    "translating"
+                ]
+            },
+            "responses.api.v1.anime.releases.latest": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                        },
+                        {
+                            "properties": {
+                                "genres": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/models.anime.genres.v1.genre"
+                                    }
+                                },
+                                "latest_episode": {
+                                    "$ref": "#/components/schemas/models.anime.releases.v1.release.episode"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                }
+            },
+            "responses.api.v1.anime.releases.random": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                }
+            },
+            "responses.api.v1.anime.releases.recommended": {
+                "title": "responses.api.v1.anime.releases.recommended",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                }
+            },
+            "responses.api.v1.anime.releases.list": {
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                },
+                                {
+                                    "properties": {
+                                        "genres": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/models.anime.genres.v1.genre"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "properties": {
+                                        "members": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/models.anime.releases.v1.release.member"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "properties": {
+                                        "episodes": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/models.anime.releases.v1.release.episode"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "properties": {
+                                        "torrents": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/models.anime.torrents.v1.torrent"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "properties": {
+                                        "sponsor": {
+                                            "$ref": "#/components/schemas/models.anime.sponsors.v1.sponsor"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/commons.v1.utils.pagination.schemes.meta"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.api.v1.anime.releases.release": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                    },
+                    {
+                        "properties": {
+                            "genres": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/models.anime.genres.v1.genre"
+                                }
+                            },
+                            "members": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/models.anime.releases.v1.release.member"
+                                }
+                            },
+                            "episodes": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/models.anime.releases.v1.release.episode"
+                                }
+                            },
+                            "torrents": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/models.anime.torrents.v1.torrent"
+                                }
+                            },
+                            "sponsor": {
+                                "$ref": "#/components/schemas/models.anime.sponsors.v1.sponsor"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "responses.api.v1.anime.releases.release.members": {
+                "title": "responses.api.v1.anime.releases.release.members",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.anime.releases.v1.release.member"
+                }
+            },
+            "responses.api.v1.anime.releases.release.episodes.timecodes": {
+                "title": "responses.api.v1.anime.releases.release.episodes.timecodes",
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.accounts.users.v1.user.view"
+                }
+            },
+            "responses.api.v1.anime.releases.episode": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.episode"
+                    },
+                    {
+                        "properties": {
+                            "release": {
+                                "type": "object",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                    },
+                                    {
+                                        "properties": {
+                                            "episodes": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/models.anime.releases.v1.release.episode"
+                                                }
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "responses.api.v1.anime.releases.episode.timecode": {
+                "title": "responses.api.v1.anime.releases.episode.timecode",
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/models.accounts.users.v1.user.view"
+                    }
+                ]
+            },
+            "models.anime.releases.v1.release.member.role": {
+                "title": "models.anime.releases.v1.release.member.role",
+                "description": "Роль участника релиза",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.releases.release.member.role"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Озвучка"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release.member": {
+                "title": "models.anime.releases.v1.release.member",
+                "description": "Участник релиза",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "example": "uuid..."
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.member.role"
+                    },
+                    "user": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/models.anime.releases.v1.release.member.user"
+                            }
+                        ],
+                        "nullable": true,
+                        "description": "Связанный с участником релиза пользователь"
+                    },
+                    "nickname": {
+                        "type": "string",
+                        "example": "Zvukar"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release.member.user": {
+                "title": "models.anime.releases.v1.release.member.user",
+                "description": "Краткая информация о пользователе",
+                "properties": {
+                    "id": {
+                        "type": "number",
+                        "example": 2346
+                    },
+                    "avatar": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release.type": {
+                "title": "models.anime.releases.v1.release.type",
+                "description": "Тип релиза",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.releases.release.type"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "ТВ"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release.name": {
+                "title": "models.anime.releases.v1.release.name",
+                "description": "Название релиза",
+                "properties": {
+                    "main": {
+                        "type": "string",
+                        "example": "Мастера Меча Онлайн: Алисизация"
+                    },
+                    "english": {
+                        "type": "string",
+                        "example": "Sword Art Online: Alicization"
+                    },
+                    "alternative": {
+                        "type": "string",
+                        "example": "Война в Андерворлде, War of Underworld"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release.season": {
+                "title": "models.anime.releases.v1.release.season",
+                "description": "Сезон релиза",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.releases.release.season"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Осень"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release.ageRating": {
+                "title": "models.anime.releases.v1.release.ageRating",
+                "description": "Возрастное ограничение",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.releases.release.ageRating"
+                    },
+                    "label": {
+                        "type": "string",
+                        "example": "16+"
+                    },
+                    "is_adult": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Для людей, достигших возраста шестнадцати лет (16+)"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release.publishDay": {
+                "title": "models.anime.releases.v1.release.publishDay",
+                "description": "День выхода релиза",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.releases.release.publishDay"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Воскресенье"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release": {
+                "title": "models.anime.releases.v1.release",
+                "description": "Данные по релизу",
+                "properties": {
+                    "id": {
+                        "description": "Идентификатор релиза",
+                        "type": "number",
+                        "example": 7439
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.type"
+                    },
+                    "year": {
+                        "description": "Год",
+                        "type": "number",
+                        "example": 2018
+                    },
+                    "name": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.name"
+                    },
+                    "alias": {
+                        "description": "Ссылка на релиз",
+                        "type": "string",
+                        "example": "sword-art-online-alicization"
+                    },
+                    "season": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.season"
+                    },
+                    "poster": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    },
+                    "fresh_at": {
+                        "description": "Дата поднятия релиза",
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2019-12-29T23:06:39+00:00"
+                    },
+                    "created_at": {
+                        "description": "Дата создания релиза",
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2019-12-29T23:06:39+00:00"
+                    },
+                    "updated_at": {
+                        "description": "Дата обновления релиза",
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2023-08-20T15:08:20+00:00"
+                    },
+                    "is_ongoing": {
+                        "description": "Релиз в данный момент выходит в стране производства",
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "age_rating": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.ageRating"
+                    },
+                    "publish_day": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.publishDay"
+                    },
+                    "description": {
+                        "description": "Описание релиза",
+                        "type": "string",
+                        "example": "Underworld - мир, ранее недоступный человеческому пониманию..."
+                    },
+                    "notification": {
+                        "description": "Важная информация / Оповещение",
+                        "type": "string",
+                        "example": "Серии выходят по воскресеньям"
+                    },
+                    "episodes_total": {
+                        "description": "Всего эпизодов",
+                        "type": "number",
+                        "example": 36
+                    },
+                    "external_player": {
+                        "description": "Ссылка на внешний плеер",
+                        "type": "string",
+                        "example": "//kodik.info/serial/..."
+                    },
+                    "is_in_production": {
+                        "description": "Релиз в работе / озвучивается",
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "is_blocked_by_geo": {
+                        "description": "Блокировка по геолокации",
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "is_blocked_by_copyrights": {
+                        "description": "Релиз заблокирован правообладателем",
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "added_in_users_favorites": {
+                        "description": "Рейтинг по добавлению в коллекцию",
+                        "type": "number",
+                        "example": 25557
+                    },
+                    "average_duration_of_episode": {
+                        "description": "Средняя продолжительность серий",
+                        "type": "number",
+                        "example": 25
+                    },
+                    "added_in_planned_collection": {
+                        "description": "Кол-во добавлений в PLANNED коллекцию",
+                        "type": "number",
+                        "example": 2457
+                    },
+                    "added_in_watched_collection": {
+                        "description": "Кол-во добавлений в WATCHED коллекцию",
+                        "type": "number",
+                        "example": 467
+                    },
+                    "added_in_watching_collection": {
+                        "description": "Кол-во добавлений в WATCHING коллекцию",
+                        "type": "number",
+                        "example": 346
+                    },
+                    "added_in_postponed_collection": {
+                        "description": "Кол-во добавлений в POSTPONED коллекцию",
+                        "type": "number",
+                        "example": 212
+                    },
+                    "added_in_abandoned_collection": {
+                        "description": "Кол-во добавлений в ABANDONED коллекцию",
+                        "type": "number",
+                        "example": 12
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release.episode.skip": {
+                "title": "models.anime.releases.v1.release.episode.skip",
+                "description": "Тайминги пропуска опенинга или эндинга",
+                "properties": {
+                    "start": {
+                        "description": "Время начала. Количество секунд от начала или конца эпизода",
+                        "type": "number",
+                        "example": 6
+                    },
+                    "stop": {
+                        "description": "Время окончания. Количество секунд от начала или конца эпизода",
+                        "type": "number",
+                        "example": 125
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.releases.v1.release.episode": {
+                "title": "models.anime.releases.v1.release.episode",
+                "description": "Эпизод релиза",
+                "properties": {
+                    "id": {
+                        "description": "Идентификатор эпизода",
+                        "type": "string",
+                        "example": "9b5e26ee-598f-4b8b-b77e-188d3e456318"
+                    },
+                    "name": {
+                        "description": "Название эпизода",
+                        "type": "string",
+                        "example": "Пролог"
+                    },
+                    "ordinal": {
+                        "description": "Номер эпизода. Может быть целым или дробным числом (например, 5 или 23.5)",
+                        "type": "number",
+                        "example": 12.5
+                    },
+                    "ending": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.episode.skip"
+                    },
+                    "opening": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.episode.skip"
+                    },
+                    "preview": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    },
+                    "hls_480": {
+                        "description": "Ссылка на поток 480p",
+                        "type": "string"
+                    },
+                    "hls_720": {
+                        "description": "Ссылка на поток 720p",
+                        "type": "string"
+                    },
+                    "hls_1080": {
+                        "description": "Ссылка на поток 1080p",
+                        "type": "string"
+                    },
+                    "duration": {
+                        "description": "Длительность эпизода в секундах",
+                        "type": "number",
+                        "example": 1432
+                    },
+                    "rutube_id": {
+                        "description": "Id эпизода на Rutube",
+                        "type": "string",
+                        "example": "c6cc4d620b1d4338901770a44b3e82f4"
+                    },
+                    "youtube_id": {
+                        "description": "Id эпизода на Youtube",
+                        "type": "string",
+                        "example": "dQw4w9WgXcQ"
+                    },
+                    "updated_at": {
+                        "description": "Дата обновления эпизода",
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2021-11-25T18:46:30+00:00"
+                    },
+                    "sort_order": {
+                        "description": "Порядковый номер эпизода для сортировки",
+                        "type": "number",
+                        "example": 12
+                    },
+                    "release_id": {
+                        "description": "Идентификатор релиза",
+                        "type": "number",
+                        "example": 9324
+                    },
+                    "name_english": {
+                        "description": "Название эпизода на английском",
+                        "type": "string",
+                        "example": "Prologue"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.v1.anime.schedule.now": {
+                "title": "responses.v1.anime.schedule.now",
+                "properties": {
+                    "today": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/models.anime.schedule.v1.releaseInSchedule"
+                        }
+                    },
+                    "tomorrow": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/models.anime.schedule.v1.releaseInSchedule"
+                        }
+                    },
+                    "yesterday": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/models.anime.schedule.v1.releaseInSchedule"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "responses.v1.anime.schedule.week": {
+                "title": "responses.v1.anime.schedule.week",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/models.anime.schedule.v1.releaseInSchedule"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.schedule.v1.releaseInSchedule": {
+                "title": "models.anime.schedule.v1.releaseInSchedule",
+                "description": "Данные по релизу в расписании",
+                "properties": {
+                    "release": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                    },
+                    "full_season_is_released": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "published_release_episode": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release.episode"
+                    },
+                    "next_release_episode_number": {
+                        "type": "integer",
+                        "example": 8,
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.sponsors.v1.sponsor": {
+                "title": "models.anime.sponsors.v1.sponsor",
+                "description": "Данные по спонсорам",
+                "properties": {
+                    "id": {
+                        "description": "Transform pattern",
+                        "type": "string",
+                        "example": "UUID"
+                    },
+                    "title": {
+                        "type": "string",
+                        "example": "Sponsor name"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Лучший спонсор в мире!"
+                    },
+                    "url_title": {
+                        "type": "string",
+                        "example": "Переходи по ссылке"
+                    },
+                    "url": {
+                        "type": "string",
+                        "example": "https://yandex.ru"
+                    }
+                },
+                "type": "object"
+            },
+            "enums.anime.torrents.torrent.codec": {
+                "title": "enums.anime.torrents.torrent.codec",
+                "description": "Список возможных значений кодека видеодорожки в торренте",
+                "type": "string",
+                "enum": [
+                    "AV1",
+                    "x264/AVC",
+                    "x265/HEVC",
+                    "x265hq/HEVC-HQ"
+                ]
+            },
+            "enums.anime.torrents.torrent.color": {
+                "title": "enums.anime.torrents.torrent.color",
+                "description": "Список возможных значений глубины цвета видеодорожки",
+                "type": "string",
+                "enum": [
+                    "8bit",
+                    "10Bit"
+                ]
+            },
+            "enums.anime.torrents.torrent.quality": {
+                "title": "enums.anime.torrents.torrent.quality",
+                "description": "Список возможных значений качества видео в торренте",
+                "type": "string",
+                "enum": [
+                    "360p",
+                    "480p",
+                    "576p",
+                    "720p",
+                    "1080p",
+                    "2k",
+                    "4k",
+                    "8k"
+                ]
+            },
+            "enums.anime.torrents.torrent.type": {
+                "title": "enums.anime.torrents.torrent.type",
+                "description": "Список возможных значений источника видео (тип релиза)",
+                "type": "string",
+                "enum": [
+                    "BDRip",
+                    "HDRip",
+                    "TVRip",
+                    "WEBRip",
+                    "DTVRip",
+                    "DVDRip",
+                    "HDTVRip",
+                    "WEB-DL",
+                    "WEB-DLRip"
+                ]
+            },
+            "enums.anime.torrents.torrentMember.role": {
+                "title": "enums.anime.torrents.torrentMember.role",
+                "description": "Список ролей участников торрента",
+                "type": "string",
+                "enum": [
+                    "HEVC"
+                ]
+            },
+            "responses.api.v1.anime.torrents": {
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/models.anime.torrents.v1.torrent"
+                                },
+                                {
+                                    "properties": {
+                                        "torrent_members": {
+                                            "type": "array",
+                                            "items": {
+                                                "allOf": [
+                                                    {
+                                                        "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.member"
+                                                    },
+                                                    {
+                                                        "properties": {
+                                                            "user": {
+                                                                "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.member.user"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                {
+                                    "properties": {
+                                        "release": {
+                                            "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/commons.v1.utils.pagination.schemes.meta"
+                    }
+                },
+                "type": "object"
+            },
+            "responses.api.v1.anime.torrent": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/models.anime.torrents.v1.torrent"
+                    },
+                    {
+                        "properties": {
+                            "torrent_members": {
+                                "type": "array",
+                                "items": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.member"
+                                        },
+                                        {
+                                            "properties": {
+                                                "user": {
+                                                    "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.member.user"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "release": {
+                                "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "responses.api.v1.anime.torrents.releaseTorrents": {
+                "type": "array",
+                "items": {
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/models.anime.torrents.v1.torrent"
+                        },
+                        {
+                            "properties": {
+                                "torrent_members": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.member"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "user": {
+                                                        "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.member.user"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "release": {
+                                    "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                }
+            },
+            "models.anime.torrents.v1.torrent.member.role": {
+                "title": "models.anime.torrents.v1.torrent.member.role",
+                "description": "Роль, которую выполняет участник торрента",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.torrents.torrentMember.role"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "HEVC"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.torrents.v1.torrent.member": {
+                "title": "models.anime.torrents.v1.torrent.member",
+                "description": "Данные по участнику торрента",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "example": "6240acf7-4f62-4de9-9cc0-b3984ccc2b35"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.member.role"
+                    },
+                    "nickname": {
+                        "type": "string",
+                        "example": "Tuxoid"
+                    },
+                    "external_url": {
+                        "type": "string",
+                        "example": "https://t.me/Animeshnik488"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.torrents.v1.torrent.member.user": {
+                "title": "models.anime.torrents.v1.torrent.member.user",
+                "description": "Данные по связанному с участником торрента пользователю",
+                "properties": {
+                    "id": {
+                        "type": "number",
+                        "example": 2346
+                    },
+                    "avatar": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.torrents.v1.torrent.type": {
+                "title": "models.anime.torrents.v1.torrent.type",
+                "description": "Тип источника видео в торренте",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.torrents.torrent.type"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "WEBRip"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.torrents.v1.torrent.quality": {
+                "title": "models.anime.torrents.v1.torrent.quality",
+                "description": "Качество видеодорожки в торренте",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.torrents.torrent.quality"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "1080p"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.torrents.v1.torrent.codec": {
+                "title": "models.anime.torrents.v1.torrent.codec",
+                "description": "Информация о кодеке видео в торренте",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.torrents.torrent.codec"
+                    },
+                    "label": {
+                        "type": "string",
+                        "example": "AVC"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "x264/AVC"
+                    },
+                    "label_color": {
+                        "description": "Цвет лейбла",
+                        "type": "string",
+                        "example": "#FFF"
+                    },
+                    "label_is_visible": {
+                        "description": "Отображать ли лейбл рядом с торрентом",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.torrents.v1.torrent.color": {
+                "title": "models.anime.torrents.v1.torrent.color",
+                "description": "Цветовая глубина видеодорожки в торренте",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.anime.torrents.torrent.color"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "8-bit"
+                    }
+                },
+                "type": "object"
+            },
+            "models.anime.torrents.v1.torrent": {
+                "title": "models.anime.torrents.v1.torrent",
+                "description": "Данные по торренту",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 18523
+                    },
+                    "hash": {
+                        "type": "string",
+                        "example": "8a8fb94b1bd22b44a116336bab6bf209d0ac3a90"
+                    },
+                    "size": {
+                        "description": "Размер торрент-файла в байтах",
+                        "type": "integer",
+                        "example": 7356495551
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.type"
+                    },
+                    "color": {
+                        "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.color"
+                    },
+                    "codec": {
+                        "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.codec"
+                    },
+                    "label": {
+                        "type": "string",
+                        "example": "Shaman King (2021) - AniLiberty.TOP [WEB-Rip 1080p]"
+                    },
+                    "quality": {
+                        "$ref": "#/components/schemas/models.anime.torrents.v1.torrent.quality"
+                    },
+                    "magnet": {
+                        "type": "string",
+                        "example": "magnet:?xt=urn:btih:QPYNLG5Y2LA2KHB7SZCQF2W3..."
+                    },
+                    "filename": {
+                        "type": "string",
+                        "example": "Shaman King (2021) - AniLiberty.TOP [WEB-Rip 1080p].torrent"
+                    },
+                    "seeders": {
+                        "description": "Количество сидеров",
+                        "type": "integer",
+                        "example": 234
+                    },
+                    "bitrate": {
+                        "description": "Битрейт, Кбит/сек",
+                        "type": "integer",
+                        "example": 3400
+                    },
+                    "leechers": {
+                        "description": "Количество личеров",
+                        "type": "integer",
+                        "example": 58
+                    },
+                    "sort_order": {
+                        "description": "Порядок сортировки торрента внутри релиза",
+                        "type": "integer",
+                        "example": 2
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2021-09-22T16:20:38+00:00"
+                    },
+                    "is_hardsub": {
+                        "description": "Является ли торрент хардсабом",
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "description": {
+                        "description": "Описание торрента",
+                        "type": "string",
+                        "example": "1-17 + OVA(1-4)"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2021-09-21T11:45:00+00:00"
+                    },
+                    "completed_times": {
+                        "description": "Общее количество скачиваний торрента",
+                        "type": "integer",
+                        "example": 13538
+                    }
+                },
+                "type": "object"
+            },
+            "responses.api.v1.app.search.releases": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                }
+            },
+            "responses.v1.app.status": {
+                "title": "responses.v1.app.status",
+                "properties": {
+                    "request": {
+                        "properties": {
+                            "ip": {
+                                "type": "string",
+                                "example": "192.168.1.1"
+                            },
+                            "country": {
+                                "type": "string",
+                                "example": "Russia"
+                            },
+                            "iso_code": {
+                                "type": "string",
+                                "example": "RU"
+                            },
+                            "timezone": {
+                                "type": "string",
+                                "example": "Europe/Moscow"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "is_alive": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "available_api_endpoints": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "https://aniliberty.top"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "responses.v1.media.promotions": {
+                "title": "responses.v1.media.promotions",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/models.media.promotions.v1.promotion"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "models.media.promotions.v1.promotion": {
+                "title": "models.media.promotions.v1.promotion",
+                "description": "Данные по промо-материалам",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "example": "bad864a4-d1b9-473f-898f-da8ee800ef87"
+                    },
+                    "url": {
+                        "description": "Кастомная ссылка на промо-материал",
+                        "type": "string",
+                        "example": "https://espritgames.ru/dragoncontract/promotions/getdragon"
+                    },
+                    "url_label": {
+                        "description": "Кастомная подпись к ссылке",
+                        "type": "string",
+                        "example": "Перейти на сайт"
+                    },
+                    "image": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    },
+                    "title": {
+                        "description": "Кастомное название промо-материала",
+                        "type": "string",
+                        "example": "Dragon Contract"
+                    },
+                    "description": {
+                        "description": "Кастомное описание промо-материала",
+                        "type": "string",
+                        "example": "ИСПЫТАЙ СВОЮ ПАМЯТЬ! Собери все пары карточек правильно, и получи дракона на старте!"
+                    },
+                    "is_ad": {
+                        "description": "Флаг рекламной промо кампании",
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "ad_erid": {
+                        "type": "string"
+                    },
+                    "ad_origin": {
+                        "type": "string"
+                    },
+                    "release": {
+                        "$ref": "#/components/schemas/models.anime.releases.v1.release"
+                    },
+                    "has_overlay": {
+                        "description": "Использовать темный оверлей",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "type": "object"
+            },
+            "enums.media.videos.video.origin.type": {
+                "title": "enums.media.videos.video.origin.type",
+                "description": "Перечисление типов источников видео",
+                "type": "string",
+                "enum": [
+                    "YOUTUBE_PLAYLIST"
+                ],
+                "example": "YOUTUBE_PLAYLIST"
+            },
+            "responses.v1.media.videos": {
+                "title": "responses.v1.media.videos",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/models.media.videos.v1.video.content"
+                                },
+                                {
+                                    "properties": {
+                                        "origin": {
+                                            "$ref": "#/components/schemas/models.media.videos.v1.video.origin"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "models.media.videos.v1.video.content": {
+                "title": "models.media.videos.v1.video.content",
+                "description": "Данные по видео роликам",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 57
+                    },
+                    "url": {
+                        "type": "string",
+                        "example": "https://www.youtube.com/watch?v=8f6FpV4sB0I"
+                    },
+                    "title": {
+                        "type": "string",
+                        "example": "ТОП 10 САМЫХ ОЖИДАЕМЫХ АНИМЕ ОСЕНИ 2021"
+                    },
+                    "views": {
+                        "description": "Количество просмотров ролика",
+                        "type": "integer",
+                        "example": 34456
+                    },
+                    "image": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    },
+                    "comments": {
+                        "description": "Количество комментариев под роликом",
+                        "type": "integer",
+                        "example": 532
+                    },
+                    "video_id": {
+                        "type": "string",
+                        "example": "8f6FpV4sB0I"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2021-09-22T16:20:38+00:00"
+                    },
+                    "updated_at": {
+                        "description": "Дата последнего обновления данных",
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2021-09-28T19:40:26+00:00"
+                    },
+                    "is_announce": {
+                        "description": "Видео является анонсом сезона",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "type": "object"
+            },
+            "models.media.videos.v1.video.origin.type": {
+                "title": "models.media.videos.v1.video.origin.type",
+                "description": "Тип источника видео",
+                "properties": {
+                    "value": {
+                        "$ref": "#/components/schemas/enums.media.videos.video.origin.type"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "YouTube плейлист"
+                    }
+                },
+                "type": "object"
+            },
+            "models.media.videos.v1.video.origin": {
+                "title": "models.media.videos.v1.video.origin",
+                "description": "Данные по видео-источнику",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "example": "e8fd32be-7f14-4c02-bf00-dbd26ecabfdb"
+                    },
+                    "url": {
+                        "type": "string",
+                        "example": "https://www.youtube.com/playlist?list=PL8_g6JPJBRglxkyQfNGugDyyQP11hL0-Q"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/models.media.videos.v1.video.origin.type"
+                    },
+                    "title": {
+                        "type": "string",
+                        "example": "Анонсы аниме-сезонов"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Плейлист с анонсами"
+                    },
+                    "is_announce": {
+                        "description": "Видео-источник является анонсом сезона",
+                        "type": "boolean",
+                        "example": true
+                    }
+                },
+                "type": "object"
+            },
+            "responses.api.v1.teams": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.teams.v1.team"
+                }
+            },
+            "responses.api.v1.teams.roles": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/models.teams.v1.team.role"
+                }
+            },
+            "responses.api.v1.teams.users": {
+                "type": "array",
+                "items": {
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/models.teams.v1.team.user"
+                        },
+                        {
+                            "properties": {
+                                "team": {
+                                    "$ref": "#/components/schemas/models.teams.v1.team"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "user": {
+                                    "$ref": "#/components/schemas/models.teams.v1.team.user.account"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "roles": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/models.teams.v1.team.role"
+                                    }
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                }
+            },
+            "models.teams.v1.team.role": {
+                "title": "models.teams.v1.team.role",
+                "description": "Данные по роли в команде",
+                "properties": {
+                    "id": {
+                        "description": "ID роли",
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "Название роли",
+                        "type": "string"
+                    },
+                    "color": {
+                        "description": "Цвет",
+                        "type": "string"
+                    },
+                    "sort_order": {
+                        "description": "Порядок сортировки роли",
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "models.teams.v1.team.user": {
+                "title": "models.teams.v1.team.user",
+                "description": "Данные по анилибрийцу",
+                "properties": {
+                    "id": {
+                        "description": "ID анилибрийца",
+                        "type": "string"
+                    },
+                    "nickname": {
+                        "description": "Псевдоним анилибрийца в команде",
+                        "type": "string"
+                    },
+                    "is_intern": {
+                        "description": "Флаг, указывающий, является ли пользователь стажером",
+                        "type": "boolean"
+                    },
+                    "sort_order": {
+                        "description": "Порядок сортировки внутри команды",
+                        "type": "integer"
+                    },
+                    "is_vacation": {
+                        "description": "Флаг, указывающий, находится ли пользователь в отпуске",
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "models.teams.v1.team.user.account": {
+                "title": "models.teams.v1.team.user.account",
+                "description": "Данные по аккаунту пользователю",
+                "properties": {
+                    "id": {
+                        "description": "ID анилибрийца",
+                        "type": "integer"
+                    },
+                    "nickname": {
+                        "description": "Псевдоним анилибрийца в команде",
+                        "type": "string"
+                    },
+                    "avatar": {
+                        "$ref": "#/components/schemas/commons.v1.models.components.image.withOptimized"
+                    }
+                },
+                "type": "object"
+            },
+            "models.teams.v1.team": {
+                "title": "models.teams.v1.team",
+                "description": "Данные по команде",
+                "properties": {
+                    "id": {
+                        "description": "ID команды",
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "Название команды",
+                        "type": "string"
+                    },
+                    "sort_order": {
+                        "description": "Порядок сортировки команды",
+                        "type": "integer"
+                    },
+                    "description": {
+                        "description": "Описание команды",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "responses": {
+            "commons.v1.http.responses.422": {
+                "description": "Ошибка валидации входных параметров",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/commons.v1.http.responses.422.content"
+                        }
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "commons.v1.utils.includeAndExclude.parameters.include": {
+                "name": "include",
+                "in": "query",
+                "description": "Список включаемых полей. Через запятую или множественные параметры. Поддерживается вложенность через точку.",
+                "required": false,
+                "schema": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "example": "id,type.genres"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "example": [
+                                "id",
+                                "type.genres"
+                            ]
+                        }
+                    ]
+                },
+                "example": "id,type.genres"
+            },
+            "commons.v1.utils.includeAndExclude.parameters.exclude": {
+                "name": "exclude",
+                "in": "query",
+                "description": "Список исключаемых полей. Через запятую или множественные параметры. Поддерживается вложенность через точку. Приоритет над include",
+                "required": false,
+                "schema": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "example": "poster,description"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "example": [
+                                "poster",
+                                "description"
+                            ]
+                        }
+                    ]
+                },
+                "example": "poster,description"
+            },
+            "commons.v1.utils.pagination.parameters.page": {
+                "name": "page",
+                "in": "query",
+                "description": "Номер страницы",
+                "schema": {
+                    "type": "integer",
+                    "example": 1
+                }
+            },
+            "commons.v1.utils.pagination.parameters.limit": {
+                "name": "limit",
+                "in": "query",
+                "description": "Ограничение на количество элементов",
+                "schema": {
+                    "type": "integer",
+                    "example": 10
+                }
+            }
+        },
+        "securitySchemes": {
+            "sessionToken": {
+                "type": "http",
+                "scheme": "bearer",
+                "description": "Bearer auth session token"
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "Аккаунты.ОдноразовыеПароли",
+            "description": "Аккаунты.ОдноразовыеПароли"
+        },
+        {
+            "name": "Аккаунты.Пользователи.Авторизация",
+            "description": "Аккаунты.Пользователи.Авторизация"
+        },
+        {
+            "name": "Аккаунты.Пользователи.Авторизация.СоциальныеСети",
+            "description": "Аккаунты.Пользователи.Авторизация.СоциальныеСети"
+        },
+        {
+            "name": "Аккаунты.Пользователи.Авторизация.Пароль",
+            "description": "Аккаунты.Пользователи.Авторизация.Пароль"
+        },
+        {
+            "name": "Аккаунты.Пользователи.Мое.Коллекции.Справочники",
+            "description": "Аккаунты.Пользователи.Мое.Коллекции.Справочники"
+        },
+        {
+            "name": "Аккаунты.Пользователи.Мое.Коллекции",
+            "description": "Аккаунты.Пользователи.Мое.Коллекции"
+        },
+        {
+            "name": "Аккаунты.Пользователи.Мое.Избранное.Справочники",
+            "description": "Аккаунты.Пользователи.Мое.Избранное.Справочники"
+        },
+        {
+            "name": "Аккаунты.Пользователи.Мое.Избранное",
+            "description": "Аккаунты.Пользователи.Мое.Избранное"
+        },
+        {
+            "name": "Аккаунты.Пользователи.Мое.Профиль",
+            "description": "Аккаунты.Пользователи.Мое.Профиль"
+        },
+        {
+            "name": "Аккаунты.Пользователи.Мое.Просмотры",
+            "description": "Аккаунты.Пользователи.Мое.Просмотры"
+        },
+        {
+            "name": "Реклама.Vasts",
+            "description": "Реклама.Vasts"
+        },
+        {
+            "name": "Аниме.Каталог",
+            "description": "Аниме.Каталог"
+        },
+        {
+            "name": "Аниме.Каталог.Справочники",
+            "description": "Аниме.Каталог.Справочники"
+        },
+        {
+            "name": "Аниме.Франшизы",
+            "description": "Аниме.Франшизы"
+        },
+        {
+            "name": "Аниме.Жанры",
+            "description": "Аниме.Жанры"
+        },
+        {
+            "name": "Аниме.Релизы",
+            "description": "Аниме.Релизы"
+        },
+        {
+            "name": "Аниме.Релизы.Эпизоды",
+            "description": "Аниме.Релизы.Эпизоды"
+        },
+        {
+            "name": "Аниме.Релизы.РасписаниеРелизов",
+            "description": "Аниме.Релизы.РасписаниеРелизов"
+        },
+        {
+            "name": "Аниме.Торренты",
+            "description": "Аниме.Торренты"
+        },
+        {
+            "name": "Приложение.Поиск",
+            "description": "Приложение.Поиск"
+        },
+        {
+            "name": "Приложение.Статус",
+            "description": "Приложение.Статус"
+        },
+        {
+            "name": "Медиа.Промо",
+            "description": "Медиа.Промо"
+        },
+        {
+            "name": "Медиа.Видеоконтент",
+            "description": "Медиа.Видеоконтент"
+        },
+        {
+            "name": "Команды",
+            "description": "Команды"
+        }
+    ],
+    "security": [
+        {
+            "sessionToken": []
+        }
+    ]
+}


### PR DESCRIPTION
Rewrites AniLibria torrent parsing to use the new v1 API for direct magnet link and size retrieval.

The previous implementation relied on the deprecated AniLibria v2 API, which required decoding base64 torrent files to extract magnet links and sizes. The new v1 API provides these details directly, simplifying the parsing logic and ensuring compatibility with the updated AniLibria service. New models for the v1 API response structure have also been added.

---
<a href="https://cursor.com/background-agent?bcId=bc-fce6c650-9836-424a-ac15-99c8c69f96c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fce6c650-9836-424a-ac15-99c8c69f96c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

